### PR TITLE
VCV-1 Add a filter by year to the Annotations List Page

### DIFF
--- a/src/components/annotate/tasks-list/page-client.tsx
+++ b/src/components/annotate/tasks-list/page-client.tsx
@@ -26,13 +26,17 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { useAnnotationTasksQuery } from '@/lib/annotate/client';
+import {
+  useAnnotationTasksQuery,
+  useAnnotationTaskYearsQuery,
+} from '@/lib/annotate/client';
 import { PAGE_SIZES } from '@/lib/shared/constants';
 import { usePagination } from '@/lib/shared/hooks/use-pagination';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { TaskRow } from './task-row';
 
 export function AnnotationTasksListPageClient() {
+  const [year, setYear] = useState<number | 'all'>('all');
   const pagination = usePagination({});
   const {
     setTotal,
@@ -45,9 +49,12 @@ export function AnnotationTasksListPageClient() {
     range: pages,
   } = pagination;
 
+  const { data: years = [] } = useAnnotationTaskYearsQuery();
+
   const { data, isLoading, isFetching } = useAnnotationTasksQuery({
     page,
     limit: pageSize,
+    taskYear: year === 'all' ? undefined : year,
   });
 
   const tasks = data?.items ?? [];
@@ -61,6 +68,11 @@ export function AnnotationTasksListPageClient() {
 
   function handleRowsPerPageChange(value: string) {
     setPageSizeAndReset(Number(value));
+  }
+
+  function handleYearChange(value: string) {
+    setPage(1);
+    setYear(value === 'all' ? 'all' : Number(value));
   }
 
   function handleNavigateToPreviousPage(
@@ -97,6 +109,19 @@ export function AnnotationTasksListPageClient() {
         <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>My Annotation Tasks</CardTitle>
           <div className="flex items-center gap-2">
+            <Select value={String(year)} onValueChange={handleYearChange}>
+              <SelectTrigger size="sm">
+                <SelectValue placeholder="Year" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All years</SelectItem>
+                {years.map(y => (
+                  <SelectItem key={y} value={String(y)}>
+                    {y}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
             <Select
               value={String(pageSize)}
               onValueChange={handleRowsPerPageChange}
@@ -165,7 +190,7 @@ export function AnnotationTasksListPageClient() {
                     href="#"
                   />
                 </PaginationItem>
-                {pages.map((pageItem) => (
+                {pages.map(pageItem => (
                   <PaginationItem key={pageItem}>
                     {pageItem === 'ellipsis' ? (
                       <PaginationEllipsis />

--- a/src/lib/annotate/client/get-annotation-task-years.ts
+++ b/src/lib/annotate/client/get-annotation-task-years.ts
@@ -1,0 +1,7 @@
+import bff from '@/lib/shared/http/client/bff-client';
+
+export async function getAnnotationTaskYears(): Promise<number[]> {
+  return bff<number[]>('/annotations/task/years', {
+    method: 'GET',
+  });
+}

--- a/src/lib/annotate/client/get-annotation-tasks.ts
+++ b/src/lib/annotate/client/get-annotation-tasks.ts
@@ -16,6 +16,7 @@ export async function getAnnotationTasks(
     limit = DEFAULT_PAGE_SIZE,
     taskTitle,
     taskStatus,
+    taskYear,
   } = filters;
 
   const query = {
@@ -23,6 +24,7 @@ export async function getAnnotationTasks(
     limit,
     title: taskTitle,
     status: taskStatus,
+    year: taskYear,
   };
 
   const data = await bff<AnnotationTasksListResponseDto>('/annotations/task', {

--- a/src/lib/annotate/client/hooks/use-annotation-task-years.ts
+++ b/src/lib/annotate/client/hooks/use-annotation-task-years.ts
@@ -1,0 +1,15 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { getAnnotationTaskYears } from '@/lib/annotate/client/get-annotation-task-years';
+
+export function useAnnotationTaskYearsQuery(
+  options?: Omit<
+    UseQueryOptions<number[], Error, number[]>,
+    'queryKey' | 'queryFn'
+  >,
+) {
+  return useQuery({
+    queryKey: ['annotations', 'task-years'] as const,
+    queryFn: getAnnotationTaskYears,
+    ...(options ?? {}),
+  });
+}

--- a/src/lib/annotate/client/hooks/use-annotation-tasks.ts
+++ b/src/lib/annotate/client/hooks/use-annotation-tasks.ts
@@ -26,6 +26,7 @@ export function useAnnotationTasksQuery(
     limit = DEFAULT_PAGE_SIZE,
     taskStatus,
     taskTitle,
+    taskYear,
   } = filters;
 
   return useQuery({
@@ -34,6 +35,7 @@ export function useAnnotationTasksQuery(
       limit,
       taskStatus,
       taskTitle,
+      taskYear,
     ) as AnnotationTasksQueryKey,
     queryFn: () => getAnnotationTasks(filters),
     ...(options ?? {}),

--- a/src/lib/annotate/client/index.ts
+++ b/src/lib/annotate/client/index.ts
@@ -5,3 +5,5 @@ export * from './hooks/use-annotation-task-progress';
 export * from './get-annotations';
 export * from './hooks/use-annotations';
 export * from '../types';
+export * from './get-annotation-task-years';
+export * from './hooks/use-annotation-task-years';

--- a/src/lib/annotate/keys.ts
+++ b/src/lib/annotate/keys.ts
@@ -1,5 +1,8 @@
 import type { QueryKey } from '@tanstack/react-query';
-import type { AnnotationStatus, AnnotationTaskStatus } from '@/lib/entities/annotation';
+import type {
+  AnnotationStatus,
+  AnnotationTaskStatus,
+} from '@/lib/entities/annotation';
 
 export const annotationKeys = {
   root: ['annotations'] as const,
@@ -8,11 +11,12 @@ export const annotationKeys = {
     limit?: number,
     taskStatus?: AnnotationTaskStatus,
     taskTitle?: string,
+    taskYear?: number,
   ) =>
     [
       ...annotationKeys.root,
       'tasks',
-      { page, limit, taskStatus, taskTitle },
+      { page, limit, taskStatus, taskTitle, taskYear },
     ] as const,
   taskProgress: (taskId: number) =>
     [...annotationKeys.root, 'task-progress', taskId] as const,

--- a/src/lib/annotate/types.ts
+++ b/src/lib/annotate/types.ts
@@ -1,10 +1,14 @@
-import type { AnnotationStatus, AnnotationTaskStatus } from '@/lib/entities/annotation';
+import type {
+  AnnotationStatus,
+  AnnotationTaskStatus,
+} from '@/lib/entities/annotation';
 
 export interface AnnotationTasksListFilters {
   page?: number;
   limit?: number;
   taskTitle?: string;
   taskStatus?: AnnotationTaskStatus;
+  taskYear?: number;
 }
 
 export interface AnnotationsListFilters {
@@ -13,4 +17,3 @@ export interface AnnotationsListFilters {
   limit?: number;
   status?: AnnotationStatus;
 }
-


### PR DESCRIPTION
- I added a dedicated backend endpoint that scans all annotation tasks and extracts the distinct years from their created/updated timestamps. It paginates through the upstream tasks, collects every year it finds, de-duplicates them, and returns a sorted list. 
- This guarantees the dropdown always reflects every year present in the data, not just what’s on the current page. On the client, we fetch that list of years via a small data function and React Query hook. The tasks list page subscribes to those years to populate the Year dropdown. 
- When a user selects a year, the tasks query includes that year as a filter, so the list reloads showing only tasks matching the selected year. It also resets pagination to the first page when the filter changes, keeping navigation consistent.