### PR TITLE
VCV-1: Add a filter by relative date to the Annotations List Page

### DIFF
--- a/src/components/annotate/tasks-list/date-range-filter.tsx
+++ b/src/components/annotate/tasks-list/date-range-filter.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  DATE_RANGE_OPTIONS,
+  type DateRangeOption,
+} from '@/lib/shared/utils/date-range';
+
+interface DateRangeFilterProps {
+  value?: DateRangeOption;
+  onValueChange: (value: DateRangeOption) => void;
+  disabled?: boolean;
+}
+
+export function DateRangeFilter({
+  value,
+  onValueChange,
+  disabled = false,
+}: DateRangeFilterProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <label
+        htmlFor="date-range"
+        className="text-muted-foreground text-sm font-medium"
+      >
+        Date Range:
+      </label>
+      <Select value={value} onValueChange={onValueChange} disabled={disabled}>
+        <SelectTrigger id="date-range" className="w-[180px]">
+          <SelectValue placeholder="Select range" />
+        </SelectTrigger>
+        <SelectContent>
+          {DATE_RANGE_OPTIONS.map(option => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/components/annotate/tasks-list/page-client.tsx
+++ b/src/components/annotate/tasks-list/page-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { AnnotationTasksListLoadingSkeleton } from '@/components/annotate/tasks-list/loading-skeleton';
+import { DateRangeFilter } from '@/components/annotate/tasks-list/date-range-filter';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Pagination,
@@ -29,10 +30,18 @@ import {
 import { useAnnotationTasksQuery } from '@/lib/annotate/client';
 import { PAGE_SIZES } from '@/lib/shared/constants';
 import { usePagination } from '@/lib/shared/hooks/use-pagination';
-import { useEffect } from 'react';
+import {
+  useDateRangeValues,
+  type DateRangeOption,
+} from '@/lib/shared/utils/date-range';
+import { useEffect, useState } from 'react';
 import { TaskRow } from './task-row';
 
 export function AnnotationTasksListPageClient() {
+  // Local state for date range filter
+  const [dateRange, setDateRange] = useState<DateRangeOption>('all-time');
+  const { fromDate, toDate } = useDateRangeValues(dateRange);
+
   const pagination = usePagination({});
   const {
     setTotal,
@@ -48,6 +57,8 @@ export function AnnotationTasksListPageClient() {
   const { data, isLoading, isFetching } = useAnnotationTasksQuery({
     page,
     limit: pageSize,
+    fromDate,
+    toDate,
   });
 
   const tasks = data?.items ?? [];
@@ -61,6 +72,12 @@ export function AnnotationTasksListPageClient() {
 
   function handleRowsPerPageChange(value: string) {
     setPageSizeAndReset(Number(value));
+  }
+
+  function handleDateRangeChange(newDateRange: DateRangeOption) {
+    setDateRange(newDateRange);
+    // Reset pagination to page 1 when date range changes
+    setPage(1);
   }
 
   function handleNavigateToPreviousPage(
@@ -96,7 +113,12 @@ export function AnnotationTasksListPageClient() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>My Annotation Tasks</CardTitle>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-4">
+            <DateRangeFilter
+              value={dateRange}
+              onValueChange={handleDateRangeChange}
+              disabled={isLoading || isFetching}
+            />
             <Select
               value={String(pageSize)}
               onValueChange={handleRowsPerPageChange}
@@ -165,7 +187,7 @@ export function AnnotationTasksListPageClient() {
                     href="#"
                   />
                 </PaginationItem>
-                {pages.map((pageItem) => (
+                {pages.map(pageItem => (
                   <PaginationItem key={pageItem}>
                     {pageItem === 'ellipsis' ? (
                       <PaginationEllipsis />

--- a/src/components/annotate/tasks-list/page-client.tsx
+++ b/src/components/annotate/tasks-list/page-client.tsx
@@ -40,7 +40,7 @@ import { TaskRow } from './task-row';
 export function AnnotationTasksListPageClient() {
   // Local state for date range filter
   const [dateRange, setDateRange] = useState<DateRangeOption>('all-time');
-  const { fromDate, toDate } = useDateRangeValues(dateRange);
+  const { createdAfter, createdBefore } = useDateRangeValues(dateRange);
 
   const pagination = usePagination({});
   const {
@@ -57,8 +57,8 @@ export function AnnotationTasksListPageClient() {
   const { data, isLoading, isFetching } = useAnnotationTasksQuery({
     page,
     limit: pageSize,
-    fromDate,
-    toDate,
+    createdAfter,
+    createdBefore,
   });
 
   const tasks = data?.items ?? [];

--- a/src/lib/annotate/client/get-annotation-tasks.ts
+++ b/src/lib/annotate/client/get-annotation-tasks.ts
@@ -16,8 +16,8 @@ export async function getAnnotationTasks(
     limit = DEFAULT_PAGE_SIZE,
     taskTitle,
     taskStatus,
-    fromDate,
-    toDate,
+    createdAfter,
+    createdBefore,
   } = filters;
 
   const query = {
@@ -25,8 +25,8 @@ export async function getAnnotationTasks(
     limit,
     title: taskTitle,
     status: taskStatus,
-    fromDate,
-    toDate,
+    createdAfter,
+    createdBefore,
   };
 
   const data = await bff<AnnotationTasksListResponseDto>('/annotations/task', {

--- a/src/lib/annotate/client/get-annotation-tasks.ts
+++ b/src/lib/annotate/client/get-annotation-tasks.ts
@@ -16,6 +16,8 @@ export async function getAnnotationTasks(
     limit = DEFAULT_PAGE_SIZE,
     taskTitle,
     taskStatus,
+    fromDate,
+    toDate,
   } = filters;
 
   const query = {
@@ -23,6 +25,8 @@ export async function getAnnotationTasks(
     limit,
     title: taskTitle,
     status: taskStatus,
+    fromDate,
+    toDate,
   };
 
   const data = await bff<AnnotationTasksListResponseDto>('/annotations/task', {

--- a/src/lib/annotate/client/hooks/use-annotation-tasks.ts
+++ b/src/lib/annotate/client/hooks/use-annotation-tasks.ts
@@ -26,6 +26,8 @@ export function useAnnotationTasksQuery(
     limit = DEFAULT_PAGE_SIZE,
     taskStatus,
     taskTitle,
+    fromDate,
+    toDate,
   } = filters;
 
   return useQuery({
@@ -34,6 +36,8 @@ export function useAnnotationTasksQuery(
       limit,
       taskStatus,
       taskTitle,
+      fromDate,
+      toDate,
     ) as AnnotationTasksQueryKey,
     queryFn: () => getAnnotationTasks(filters),
     ...(options ?? {}),

--- a/src/lib/annotate/client/hooks/use-annotation-tasks.ts
+++ b/src/lib/annotate/client/hooks/use-annotation-tasks.ts
@@ -26,8 +26,8 @@ export function useAnnotationTasksQuery(
     limit = DEFAULT_PAGE_SIZE,
     taskStatus,
     taskTitle,
-    fromDate,
-    toDate,
+    createdAfter,
+    createdBefore,
   } = filters;
 
   return useQuery({
@@ -36,8 +36,8 @@ export function useAnnotationTasksQuery(
       limit,
       taskStatus,
       taskTitle,
-      fromDate,
-      toDate,
+      createdAfter,
+      createdBefore,
     ) as AnnotationTasksQueryKey,
     queryFn: () => getAnnotationTasks(filters),
     ...(options ?? {}),

--- a/src/lib/annotate/keys.ts
+++ b/src/lib/annotate/keys.ts
@@ -1,5 +1,8 @@
 import type { QueryKey } from '@tanstack/react-query';
-import type { AnnotationStatus, AnnotationTaskStatus } from '@/lib/entities/annotation';
+import type {
+  AnnotationStatus,
+  AnnotationTaskStatus,
+} from '@/lib/entities/annotation';
 
 export const annotationKeys = {
   root: ['annotations'] as const,
@@ -8,13 +11,13 @@ export const annotationKeys = {
     limit?: number,
     taskStatus?: AnnotationTaskStatus,
     taskTitle?: string,
-    fromDate?: string,
-    toDate?: string,
+    createdAfter?: string,
+    createdBefore?: string,
   ) =>
     [
       ...annotationKeys.root,
       'tasks',
-      { page, limit, taskStatus, taskTitle, fromDate, toDate },
+      { page, limit, taskStatus, taskTitle, createdAfter, createdBefore },
     ] as const,
   taskProgress: (taskId: number) =>
     [...annotationKeys.root, 'task-progress', taskId] as const,

--- a/src/lib/annotate/keys.ts
+++ b/src/lib/annotate/keys.ts
@@ -8,11 +8,13 @@ export const annotationKeys = {
     limit?: number,
     taskStatus?: AnnotationTaskStatus,
     taskTitle?: string,
+    fromDate?: string,
+    toDate?: string,
   ) =>
     [
       ...annotationKeys.root,
       'tasks',
-      { page, limit, taskStatus, taskTitle },
+      { page, limit, taskStatus, taskTitle, fromDate, toDate },
     ] as const,
   taskProgress: (taskId: number) =>
     [...annotationKeys.root, 'task-progress', taskId] as const,

--- a/src/lib/annotate/types.ts
+++ b/src/lib/annotate/types.ts
@@ -5,6 +5,8 @@ export interface AnnotationTasksListFilters {
   limit?: number;
   taskTitle?: string;
   taskStatus?: AnnotationTaskStatus;
+  fromDate?: string;
+  toDate?: string;
 }
 
 export interface AnnotationsListFilters {

--- a/src/lib/annotate/types.ts
+++ b/src/lib/annotate/types.ts
@@ -1,12 +1,15 @@
-import type { AnnotationStatus, AnnotationTaskStatus } from '@/lib/entities/annotation';
+import type {
+  AnnotationStatus,
+  AnnotationTaskStatus,
+} from '@/lib/entities/annotation';
 
 export interface AnnotationTasksListFilters {
   page?: number;
   limit?: number;
   taskTitle?: string;
   taskStatus?: AnnotationTaskStatus;
-  fromDate?: string;
-  toDate?: string;
+  createdAfter?: string;
+  createdBefore?: string;
 }
 
 export interface AnnotationsListFilters {
@@ -15,4 +18,3 @@ export interface AnnotationsListFilters {
   limit?: number;
   status?: AnnotationStatus;
 }
-

--- a/src/lib/shared/utils/date-range.ts
+++ b/src/lib/shared/utils/date-range.ts
@@ -8,8 +8,8 @@ export type DateRangeOption =
   | 'all-time';
 
 export interface DateRange {
-  fromDate?: string;
-  toDate: string;
+  createdAfter?: string;
+  createdBefore: string;
 }
 
 export const DATE_RANGE_OPTIONS = [
@@ -22,48 +22,50 @@ export const DATE_RANGE_OPTIONS = [
 
 export function calculateDateRange(option: DateRangeOption): DateRange {
   const now = new Date();
-  const toDate = now.toISOString();
+  const createdBefore = now.toISOString();
 
   if (option === 'all-time') {
-    return { toDate };
+    return { createdBefore };
   }
 
-  const fromDate = new Date(now);
+  const createdAfter = new Date(now);
 
   switch (option) {
     case '1-month':
-      fromDate.setMonth(fromDate.getMonth() - 1);
+      createdAfter.setMonth(createdAfter.getMonth() - 1);
       break;
     case '3-months':
-      fromDate.setMonth(fromDate.getMonth() - 3);
+      createdAfter.setMonth(createdAfter.getMonth() - 3);
       break;
     case '6-months':
-      fromDate.setMonth(fromDate.getMonth() - 6);
+      createdAfter.setMonth(createdAfter.getMonth() - 6);
       break;
     case '1-year':
-      fromDate.setFullYear(fromDate.getFullYear() - 1);
+      createdAfter.setFullYear(createdAfter.getFullYear() - 1);
       break;
   }
 
   return {
-    fromDate: fromDate.toISOString(),
-    toDate,
+    createdAfter: createdAfter.toISOString(),
+    createdBefore,
   };
 }
 
 export function getDateRangeOptionFromDates(
-  fromDate?: string,
-  toDate?: string,
+  createdAfter?: string,
+  createdBefore?: string,
 ): DateRangeOption | null {
-  if (!fromDate || !toDate) {
-    return fromDate === undefined && toDate === undefined ? 'all-time' : null;
+  if (!createdAfter || !createdBefore) {
+    return createdAfter === undefined && createdBefore === undefined
+      ? 'all-time'
+      : null;
   }
 
-  const from = new Date(fromDate);
-  const to = new Date(toDate);
+  const from = new Date(createdAfter);
+  const to = new Date(createdBefore);
   const now = new Date();
 
-  // Check if toDate is close to now (within 1 minute)
+  // Check if createdBefore is close to now (within 1 minute)
   const timeDiff = Math.abs(to.getTime() - now.getTime());
   if (timeDiff > 60000) {
     // More than 1 minute difference

--- a/src/lib/shared/utils/date-range.ts
+++ b/src/lib/shared/utils/date-range.ts
@@ -1,0 +1,93 @@
+import { useMemo } from 'react';
+
+export type DateRangeOption =
+  | '1-month'
+  | '3-months'
+  | '6-months'
+  | '1-year'
+  | 'all-time';
+
+export interface DateRange {
+  fromDate?: string;
+  toDate: string;
+}
+
+export const DATE_RANGE_OPTIONS = [
+  { value: '1-month' as const, label: 'Last 1 Month' },
+  { value: '3-months' as const, label: 'Last 3 Months' },
+  { value: '6-months' as const, label: 'Last 6 Months' },
+  { value: '1-year' as const, label: 'Last 1 Year' },
+  { value: 'all-time' as const, label: 'All Time' },
+] as const;
+
+export function calculateDateRange(option: DateRangeOption): DateRange {
+  const now = new Date();
+  const toDate = now.toISOString();
+
+  if (option === 'all-time') {
+    return { toDate };
+  }
+
+  const fromDate = new Date(now);
+
+  switch (option) {
+    case '1-month':
+      fromDate.setMonth(fromDate.getMonth() - 1);
+      break;
+    case '3-months':
+      fromDate.setMonth(fromDate.getMonth() - 3);
+      break;
+    case '6-months':
+      fromDate.setMonth(fromDate.getMonth() - 6);
+      break;
+    case '1-year':
+      fromDate.setFullYear(fromDate.getFullYear() - 1);
+      break;
+  }
+
+  return {
+    fromDate: fromDate.toISOString(),
+    toDate,
+  };
+}
+
+export function getDateRangeOptionFromDates(
+  fromDate?: string,
+  toDate?: string,
+): DateRangeOption | null {
+  if (!fromDate || !toDate) {
+    return fromDate === undefined && toDate === undefined ? 'all-time' : null;
+  }
+
+  const from = new Date(fromDate);
+  const to = new Date(toDate);
+  const now = new Date();
+
+  // Check if toDate is close to now (within 1 minute)
+  const timeDiff = Math.abs(to.getTime() - now.getTime());
+  if (timeDiff > 60000) {
+    // More than 1 minute difference
+    return null;
+  }
+
+  const monthsDiff =
+    (now.getFullYear() - from.getFullYear()) * 12 +
+    (now.getMonth() - from.getMonth());
+
+  if (monthsDiff <= 1) return '1-month';
+  if (monthsDiff <= 3) return '3-months';
+  if (monthsDiff <= 6) return '6-months';
+  if (monthsDiff <= 12) return '1-year';
+
+  return null;
+}
+
+/**
+ * Hook to get memoized ISO date values from a date range option
+ * This keeps react-query caching stable by ensuring consistent date values
+ */
+export function useDateRangeValues(option: DateRangeOption) {
+  return useMemo(() => {
+    return calculateDateRange(option);
+  }, [option]);
+}


### PR DESCRIPTION
- Local state management - Date range selection (1-month, 3-months, etc.) is stored in component state, with automatic conversion to ISO date strings for backend queries Backend filtering 
- The actual data filtering is handled by the BFF using fromDate/toDate query parameters, so the server does the heavy lifting of filtering annotation tasks by date range Automatic pagination reset 
- When users change the date filter, pagination automatically resets to page 1 since the filtered dataset changes, ensuring users see results from the beginning of the new date range