### PR TITLE
VCV-7: Add Zod validation to the dropdowns, notes, and flag specimen button

### DIFF
--- a/src/components/annotate/task-detail/annotation-form-panel/morph-id-select-menu.tsx
+++ b/src/components/annotate/task-detail/annotation-form-panel/morph-id-select-menu.tsx
@@ -9,6 +9,7 @@ interface MorphIdSelectMenuProps {
     selectedMorphId: string | undefined;
     onMorphSelect: (morphId?: string) => void;
     disabled?: boolean;
+    inValid?: boolean;
 }
 
 export default function MorphIdSelectMenu({
@@ -17,6 +18,7 @@ export default function MorphIdSelectMenu({
     selectedMorphId,
     onMorphSelect,
     disabled,
+    inValid,
 }: MorphIdSelectMenuProps) {
     return (
         <Select
@@ -24,7 +26,13 @@ export default function MorphIdSelectMenu({
             onValueChange={(value) => onMorphSelect(value === "clear" ? undefined : value)}
             disabled={disabled}
         >
-            <SelectTrigger className="w-full" id={toDomId(label)}>
+            <SelectTrigger 
+            id={toDomId(label)}
+            className= {cn(
+                "w-full",
+                inValid && "border-destructive focus:border-destructive focus:ring-destructive"
+            )}
+            >
                 <SelectValue
                     placeholder={`Select ${label}...`}
                 >

--- a/src/components/annotate/task-detail/annotation-form-panel/validation/annotation-form-schema.ts
+++ b/src/components/annotate/task-detail/annotation-form-panel/validation/annotation-form-schema.ts
@@ -3,6 +3,7 @@ import {
     SEX_MORPH_IDS,
     ABDOMEN_STATUS_MORPH_IDS,
 } from '@/lib/entities/specimen/morph-ids';
+import { spec } from 'node:test/reporters';
 
 import { z } from 'zod';
 
@@ -17,6 +18,10 @@ export const AnnotationBase = z.object({
   notes: z.string().optional(),
   flagged: z.boolean().default(false),
 });
+export const isSexEnabled = (species?: string) => 
+    species !== SPECIES_MORPH_IDS.NON_MOSQUITO;
+export const isAbdomenStatusEnabled = (species?: string, sex?: string) =>
+    isSexEnabled(species) && sex !== SEX_MORPH_IDS.MALE;
 
 export const annotationFormSchema = AnnotationBase.superRefine(
     (formFields, context) => {
@@ -42,9 +47,7 @@ export const annotationFormSchema = AnnotationBase.superRefine(
             return;
         }
 
-        if (formFields.species === undefined) {
-            return;
-        }
+
 
         if (!formFields.sex) {
             context.addIssue({
@@ -60,9 +63,7 @@ export const annotationFormSchema = AnnotationBase.superRefine(
             return;
         }
 
-        if (formFields.sex === undefined) {
-            return;
-        }
+ 
 
         if (!formFields.abdomenStatus) {
             context.addIssue({
@@ -72,9 +73,8 @@ export const annotationFormSchema = AnnotationBase.superRefine(
             });
         }
 
-        if (formFields.abdomenStatus === undefined) {
-            return;
-        }
+
+
     }
 )
 

--- a/src/components/annotate/task-detail/annotation-form-panel/validation/annotation-form-schema.ts
+++ b/src/components/annotate/task-detail/annotation-form-panel/validation/annotation-form-schema.ts
@@ -1,0 +1,82 @@
+import {
+    SPECIES_MORPH_IDS,
+    SEX_MORPH_IDS,
+    ABDOMEN_STATUS_MORPH_IDS,
+} from '@/lib/entities/specimen/morph-ids';
+
+import { z } from 'zod';
+
+const SPECIES_VALUES = Object.values(SPECIES_MORPH_IDS) as [string, ... string[]];
+const SEX_VALUES = Object.values(SEX_MORPH_IDS) as [string, ... string[]];
+const ABDOMEN_STATUS_VALUES = Object.values(ABDOMEN_STATUS_MORPH_IDS) as [string, ... string[]];
+
+export const AnnotationBase = z.object({
+  species: z.enum(SPECIES_VALUES).optional(),
+  sex: z.enum(SEX_VALUES).optional(),
+  abdomenStatus: z.enum(ABDOMEN_STATUS_VALUES).optional(),
+  notes: z.string().optional(),
+  flagged: z.boolean().default(false),
+});
+
+export const annotationFormSchema = AnnotationBase.superRefine(
+    (formFields, context) => {
+        if (formFields.flagged) {
+            if (!formFields.notes || formFields.notes.trim().length === 0) {
+                context.addIssue({
+                    code: "custom",
+                    path: ["notes"],
+                    message: "Notes are required when the specimen is flagged.",
+                });
+            }
+            return;
+        }
+        if (!formFields.species) {
+            context.addIssue({
+                code: "custom",
+                path: ["species"],
+                message: "Species is required when the specimen is not flagged.",
+            });
+        }
+
+        if (formFields.species === SPECIES_MORPH_IDS.NON_MOSQUITO) {
+            return;
+        }
+
+        if (formFields.species === undefined) {
+            return;
+        }
+
+        if (!formFields.sex) {
+            context.addIssue({
+                code: "custom",
+                path: ["sex"],
+                message: "Sex is required when the specimen is not flagged.",
+            });
+        }
+
+
+
+        if (formFields.sex === SEX_MORPH_IDS.MALE) {
+            return;
+        }
+
+        if (formFields.sex === undefined) {
+            return;
+        }
+
+        if (!formFields.abdomenStatus) {
+            context.addIssue({
+                code: "custom",
+                path: ["abdomenStatus"],
+                message: "Abdomen status is required when the specimen is not flagged.",
+            });
+        }
+
+        if (formFields.abdomenStatus === undefined) {
+            return;
+        }
+    }
+)
+
+export type AnnotationFormInput = z.input<typeof annotationFormSchema>;
+export type AnnotationFormOutput = z.output<typeof annotationFormSchema>;

--- a/src/components/annotate/task-detail/page-client.tsx
+++ b/src/components/annotate/task-detail/page-client.tsx
@@ -10,6 +10,11 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { 
+  annotationFormSchema,
+  AnnotationFormOutput,
+  AnnotationFormInput
+} from './annotation-form-panel/validation/annotation-form-schema';
 import {
   useAnnotationTaskProgressQuery,
   useTaskAnnotationsQuery,
@@ -29,20 +34,46 @@ import {
   SEX_MORPH_IDS,
   ABDOMEN_STATUS_MORPH_IDS,
 } from '@/lib/entities/specimen/morph-ids';
-
+import { toDomId } from '@/lib/shared/utils/dom';
+import {
+  Form,  
+  FormField,
+  FormControl, 
+  FormItem, 
+  FormLabel, 
+  FormMessage,
+} from '@/components/ui/form';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 interface AnnotationTaskDetailPageClientProps {
   taskId: number;
+  onSubmit?: (values: AnnotationFormOutput) => Promise<void> | void;
+  className?: string;
 }
 
 export function AnnotationTaskDetailPageClient({
   taskId,
+  onSubmit,
+  className,
 }: AnnotationTaskDetailPageClientProps) {
   const [page, setPage] = useState(1);
-  const [selectedSpecies, setSelectedSpecies] = useState<string | undefined>();
-  const [selectedSex, setSelectedSex] = useState<string | undefined>();
-  const [selectedAbdomenStatus, setSelectedAbdomenStatus] = useState<string | undefined>();
-  const [isFlagged, setIsFlagged] = useState(false);
-  const [notes, setNotes] = useState('');
+
+  const annotationForm = useForm<AnnotationFormInput>({
+    resolver: zodResolver(annotationFormSchema),
+    defaultValues: {
+      species: undefined,
+      sex: undefined,
+      abdomenStatus: undefined,
+      notes: undefined,
+      flagged: false,
+    },
+    mode: "onSubmit",
+    reValidateMode: "onChange",
+  });
+  const selectedSpecies = annotationForm.watch('species');
+  const selectedSex = annotationForm.watch('sex');
+  const selectedAbdomenStatus = annotationForm.watch('abdomenStatus');
+  const isFlagged = annotationForm.watch('flagged');
 
   const lockingSpecies = SPECIES_MORPH_IDS.NON_MOSQUITO;
   const lockingOutFromSpecies = selectedSpecies === lockingSpecies;
@@ -51,12 +82,15 @@ export function AnnotationTaskDetailPageClient({
 
   useEffect(() => {
     if (lockingOutFromSpecies) {
-      if (selectedSex !== undefined) setSelectedSex(undefined);
-      if (selectedAbdomenStatus !== undefined) setSelectedAbdomenStatus(undefined);
+      annotationForm.setValue('sex', undefined);
+      annotationForm.setValue('abdomenStatus', undefined);
+      annotationForm.clearErrors(['sex', 'abdomenStatus']);
       return;
     }
-    if (lockingOutFromSex && selectedAbdomenStatus !== undefined) {
-      setSelectedAbdomenStatus(undefined);
+    if (lockingOutFromSex) {
+      annotationForm.setValue('abdomenStatus', undefined);
+      annotationForm.clearErrors(['abdomenStatus']);
+      return;
     }
   }, [lockingOutFromSpecies, lockingOutFromSex, selectedSex, selectedAbdomenStatus]);
 
@@ -91,50 +125,42 @@ export function AnnotationTaskDetailPageClient({
     return `/api/bff${relativePath.startsWith('/') ? relativePath : `/${relativePath}`}`;
   }, [currentAnnotation]);
 
-  const handleFlagged = useCallback(() => {
-    setIsFlagged(!isFlagged);
-    console.log('Flagging specimen', {
-      specimenId: currentAnnotation?.specimen?.id,
-      flagged: !isFlagged,
-      notes: notes.trim() || "Flagged for review"
-    })
-  }, [isFlagged, currentAnnotation, notes]);
+  const handleFlagged = (
+    newFlagged: boolean,
+    updateFormValue: (value: boolean) => void
+  ) => {
+    updateFormValue(newFlagged);
 
-  const handleSave = useCallback(() => {
-    console.log('Saving annotation', {
-      species: selectedSpecies,
-      sex: selectedSex,
-      abdomenStatus: selectedAbdomenStatus,
-      notes: notes.trim() || undefined,
-      specimenId: currentAnnotation?.specimen?.id,
-      flagged: isFlagged,
-    })
+    if (newFlagged) {
+      annotationForm.clearErrors(["species", "sex", "abdomenStatus"])
+    } else {
+      annotationForm.clearErrors(["notes"])
+    }
+  }
 
-    setSelectedSpecies(undefined);
-    setSelectedSex(undefined);
-    setSelectedAbdomenStatus(undefined);
-    setIsFlagged(false);
-    setNotes('');
-    
-  }, [selectedSpecies, selectedSex, selectedAbdomenStatus, notes, isFlagged, currentAnnotation]);
 
   const handleNext = useCallback(() => {
     if (hasMore && !isFetching && !isLoading) {
       setPage(prev => prev + 1);
-      setSelectedSpecies(undefined);
-      setSelectedSex(undefined);
-      setSelectedAbdomenStatus(undefined);
+      annotationForm.reset();
     }
   }, [hasMore, isFetching, isLoading]);
 
   const handlePrevious = useCallback(() => {
     if (page > 1 && !isFetching && !isLoading) {
       setPage(prev => Math.max(prev - 1, 1));
-      setSelectedSpecies(undefined);
-      setSelectedSex(undefined);
-      setSelectedAbdomenStatus(undefined);
+      annotationForm.reset();
     }
   }, [page, isFetching, isLoading]);
+
+  const handleValidSubmit = (formInput: AnnotationFormInput) => {
+    const validatedFormOutput = annotationFormSchema.parse(formInput);
+    if (typeof onSubmit === 'function') {
+      return onSubmit(validatedFormOutput);
+    }
+    console.warn('onSubmit prop not provided - Data:', validatedFormOutput);
+  };
+
 
   const createdAt = currentAnnotation?.createdAt
     ? formatDate(currentAnnotation.createdAt).monthYear
@@ -191,102 +217,171 @@ export function AnnotationTaskDetailPageClient({
           </CardTitle>
           <TaskProgressBreakdown taskProgress={taskProgress} />
         </CardHeader>
-        <CardContent className="space-y-6">
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <h3 className="text-foreground text-sm font-bold">Species</h3>
-              <MorphIdSelectMenu
-                label="Species"
-                morphIds={Object.values(SPECIES_MORPH_IDS)}
-                selectedMorphId={selectedSpecies}
-                onMorphSelect={setSelectedSpecies}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <h3 className="text-foreground text-sm font-bold">Sex</h3>
-              <MorphIdSelectMenu
-                label="Sex"
-                morphIds={Object.values(SEX_MORPH_IDS)}
-                selectedMorphId={selectedSex}
-                onMorphSelect={setSelectedSex}
-                disabled={lockingOutFromSpecies}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <h3 className="text-foreground text-sm font-bold">Abdomen Status</h3>
-              <MorphIdSelectMenu
-                label="Abdomen Status"
-                morphIds={Object.values(ABDOMEN_STATUS_MORPH_IDS)}
-                selectedMorphId={selectedAbdomenStatus}
-                onMorphSelect={setSelectedAbdomenStatus}
-                disabled={lockingOutFromSpecies || lockingOutFromSex}
-              />
-            </div>
-            <div className="space-y-2">
-              <h3 className="text-foreground text-sm font-bold">Notes</h3>
-              <Textarea
-                className="h-[70px] resize-none text-sm overflow-y-auto"
-                placeholder="Add observations..."
-                value={notes}
-                onChange={(e) => setNotes(e.target.value)}
-              />
-            </div>
-
-            <div className="flex gap-3 pt-2">
-              <Toggle
-                pressed={isFlagged}
-                onPressedChange={setIsFlagged}
-                variant="outline"
-                disabled={isFetching || isLoading}
-                data-state={isFlagged ? 'on' : 'off'}
-                className={cn(
-                  "flex-1", 
-                  "flex items-center justify-center gap-1.5 rounded-md border transition-colors",
-                  "data-[state=on]:bg-destructive/10 data-[state=on]:text-destructive data-[state=on]:border-destructive data-[state=on]:hover:bg-destructive/20 motion-safe:data-[state=on]:animate-pulse",
-                  "data-[state=off]:bg-background data-[state=off]:border-input data-[state=off]:hover:bg-accent data-[state=off]:hover:text-accent-foreground"
-                )}
+      <div>
+        <CardContent className = "pt-0">
+          <Form {...annotationForm}>
+            <form
+              onSubmit={annotationForm.handleSubmit(handleValidSubmit)}
+              className={cn("space-y-3", className)}
+            >
+              <fieldset
+                disabled={annotationForm.formState.isSubmitting}
+                className="space-y-3"
               >
-                <Flag className={cn(
-                  "h-4 w-4", 
-                  isFlagged ? "text-destructive" : "text-muted-foreground"
-                )} />
-                {isFlagged ? 'Specimen Flagged' : 'Flag Specimen'}
-              </Toggle>
+                <FormField
+                  control={annotationForm.control}
+                  name="species"
+                  render={({ field, fieldState }) => (
+                    <FormItem>
+                      <FormLabel htmlFor={toDomId(field.name)} className="m-0">Species</FormLabel>
+                      <FormControl>
+                        <MorphIdSelectMenu
+                          label="Species"
+                          morphIds={Object.values(SPECIES_MORPH_IDS)}
+                          selectedMorphId={field.value}
+                          onMorphSelect={(value) => field.onChange(value)}
+                          inValid={!!fieldState.error}
+                        />
+                      </FormControl>
+                      <FormMessage className="text-xs" />
+                    </FormItem>
 
-              <Button
-                type="button"
-                className="flex-1 flex items-center justify-center gap-1.5" 
-                onClick={handleSave}
-                disabled={isFetching || isLoading}
-              >
-                <Save className="h-4 w-4" /> Save
-              </Button>
-            </div>
-          </div>
+                  )}
+                />
 
+                    <FormField
+                  control={annotationForm.control}
+                  name="sex"
+                  render={({ field, fieldState }) => (
+                    <FormItem>
+                      <FormLabel htmlFor={toDomId(field.name)} className="m-0">Sex</FormLabel>
+                      <FormControl>
+                        <MorphIdSelectMenu
+                          label="Sex"
+                          morphIds={Object.values(SEX_MORPH_IDS)}
+                          selectedMorphId={field.value}
+                          onMorphSelect={(value) => field.onChange(value)}
+                          disabled={lockingOutFromSpecies}
+                          inValid={!!fieldState.error && !lockingOutFromSpecies}
+                        />
+                      </FormControl>
+                      <FormMessage className="text-xs" />
+                    </FormItem>
+
+                  )}
+                />
+
+                <FormField
+                  control={annotationForm.control}
+                  name="abdomenStatus"
+                  render={({ field, fieldState }) => (
+                    <FormItem>
+                      <FormLabel htmlFor={toDomId(field.name)} className="m-0">Abdomen Status</FormLabel>
+                      <FormControl>
+                        <MorphIdSelectMenu
+                          label="Abdomen Status"
+                          morphIds={Object.values(ABDOMEN_STATUS_MORPH_IDS)}
+                          selectedMorphId={field.value}
+                          onMorphSelect={(value) => field.onChange(value)}
+                          disabled={lockingOutFromSpecies || lockingOutFromSex}
+                          inValid={!!fieldState.error && !(lockingOutFromSpecies || lockingOutFromSex)}
+                        />
+                      </FormControl>
+                      <FormMessage className="text-xs" />
+                    </FormItem>
+
+                  )}
+                />
+
+                    <FormField
+                      control={annotationForm.control}
+                      name="notes"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel htmlFor={toDomId(field.name)} className="m-0">
+                            Notes
+                            {isFlagged && (
+                              <span className="text-destructive">(Required)*</span>
+                            )}
+                            </FormLabel>
+                          <FormControl>
+                            <Textarea
+                              id={toDomId(field.name)}
+                              className="h-[70px] resize-none text-sm overflow-y-auto"
+                              placeholder="Add observations..."
+                              {...field}
+                              />
+                          </FormControl>
+                          <FormMessage/>
+                        </FormItem>
+                      )}
+                    />
+
+                    <div className="flex gap-3 pt-2">
+                      <FormField
+                        control={annotationForm.control}
+                        name="flagged"
+                        render={({ field }) => (
+                          <Toggle
+                            pressed={field.value}
+                            onPressedChange={(newFlagged) => handleFlagged(newFlagged, field.onChange)}
+                            variant="outline"
+                            disabled={annotationForm.formState.isSubmitting}
+                            className={cn(
+                              "flex-1", 
+                              "flex items-center justify-center gap-1.5 rounded-md border transition-colors",
+                              "data-[state=on]:bg-destructive/10 data-[state=on]:text-destructive data-[state=on]:border-destructive data-[state=on]:hover:bg-destructive/20 motion-safe:data-[state=on]:animate-pulse",
+                              "data-[state=off]:bg-background data-[state=off]:border-input data-[state=off]:hover:bg-accent data-[state=off]:hover:text-accent-foreground"
+                            )}
+                          >
+                            <Flag className={cn(
+                              "h-4 w-4", 
+                              field.value ? "text-destructive" : "text-muted-foreground"
+                            )} />
+                            {field.value ? 'Specimen Flagged' : 'Flag Specimen'}
+                          </Toggle>
+                        )}
+                          
+                      />
+                      
+
+                      <Button
+                        type="submit"
+                        className="flex-1 flex items-center justify-center gap-1.5" 
+                        disabled={annotationForm.formState.isSubmitting}
+                      >
+                        <Save className="h-4 w-4" /> 
+                        {annotationForm.formState.isSubmitting ? 'Submitting...' : 'Submit'}
+                      </Button>
+                    </div>
+
+                <CardFooter className="mt-auto flex flex-wrap items-center justify-between gap-3 px-6 py-4">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="min-w-[120px]"
+                    onClick={handlePrevious}
+                    disabled={page === 1 || isFetching || isLoading}
+                  >
+                    <ArrowLeft className="mr-2 h-4 w-4" /> Previous
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="min-w-[120px]"
+                    onClick={handleNext}
+                    disabled={!hasMore || isFetching || isLoading}
+                  >
+                    Next <ArrowRight className="ml-2 h-4 w-4" />
+                  </Button>
+                </CardFooter>
+              </fieldset>
+            </form>
+          </Form>
         </CardContent>
-        <CardFooter className="mt-auto flex flex-wrap items-center justify-between gap-3 px-6 py-4">
-          <Button
-            type="button"
-            variant="outline"
-            className="min-w-[120px]"
-            onClick={handlePrevious}
-            disabled={page === 1 || isFetching || isLoading}
-          >
-            <ArrowLeft className="mr-2 h-4 w-4" /> Previous
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            className="min-w-[120px]"
-            onClick={handleNext}
-            disabled={!hasMore || isFetching || isLoading}
-          >
-            Next <ArrowRight className="ml-2 h-4 w-4" />
-          </Button>
-        </CardFooter>
+        
+      </div>
+        
       </Card>
     </div>
   );


### PR DESCRIPTION
created validation so that if the specimen is not flagged -- species, sex, and abdomen status select menu must be selected.

if specimen is flagged, there must be something in notes box.

switched out cards for forms in order to implement zod validation, which can be found in components/annotate/task-detail/annotation-form-panel/validation. if user clicks clear select, validation disappears. and if select menu is blanked out, there will be no validation. 