### PR TITLE
VCV-9: Add a client-side PUT hook for submitting an annotation

### DIFF
--- a/src/components/annotate/task-detail/annotation-form-panel/annotation-form.tsx
+++ b/src/components/annotate/task-detail/annotation-form-panel/annotation-form.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+import {
+  Form,
+  FormField,
+  FormControl,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  AnnotationFormInput,
+  annotationFormSchema,
+  isAbdomenStatusEnabled,
+  isSexEnabled,
+} from './validation/annotation-form-schema';
+import { cn } from '@/lib/utils';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Toggle } from '@/components/ui/toggle';
+import { Flag, Save } from 'lucide-react';
+import { toDomId } from '@/lib/shared/utils/dom';
+import MorphIdSelectMenu from '../annotation-form-panel/morph-id-select-menu';
+import {
+  SPECIES_MORPH_IDS,
+  SEX_MORPH_IDS,
+  ABDOMEN_STATUS_MORPH_IDS,
+} from '@/lib/entities/specimen/morph-ids';
+
+interface AnnotationFormProps {
+  className?: string;
+  onSubmit?: (values: AnnotationFormInput) => Promise<void> | void;
+}
+
+export function AnnotationForm({
+  className = '',
+  onSubmit,
+}: AnnotationFormProps) {
+  const annotationForm = useForm<AnnotationFormInput>({
+    resolver: zodResolver(annotationFormSchema),
+    defaultValues: {
+      species: undefined,
+      sex: undefined,
+      abdomenStatus: undefined,
+      notes: undefined,
+      flagged: false,
+    },
+    mode: 'onSubmit',
+    reValidateMode: 'onChange',
+  });
+
+  const selectedSpecies = annotationForm.watch('species');
+  const selectedSex = annotationForm.watch('sex');
+  const isFlagged = annotationForm.watch('flagged');
+
+  // Calculate enabled states for form fields
+  const sexEnabled = isSexEnabled(selectedSpecies);
+  const abdomenStatusEnabled = isAbdomenStatusEnabled(
+    selectedSpecies,
+    selectedSex,
+  );
+
+  const handleSpeciesSelect = (newSpecies?: string) => {
+    annotationForm.setValue('species', newSpecies, { shouldDirty: true });
+    if (!isSexEnabled(newSpecies)) {
+      annotationForm.setValue('sex', undefined, {
+        shouldDirty: true,
+        shouldValidate: false,
+      });
+      annotationForm.setValue('abdomenStatus', undefined, {
+        shouldDirty: true,
+        shouldValidate: false,
+      });
+      annotationForm.clearErrors(['sex', 'abdomenStatus']);
+    }
+    annotationForm.clearErrors('species');
+  };
+
+  const handleSexSelect = (newSex?: string) => {
+    annotationForm.setValue('sex', newSex, { shouldDirty: true });
+    if (!isAbdomenStatusEnabled(selectedSpecies, newSex)) {
+      annotationForm.setValue('abdomenStatus', undefined, {
+        shouldDirty: true,
+        shouldValidate: false,
+      });
+      annotationForm.clearErrors(['abdomenStatus']);
+    }
+    annotationForm.clearErrors('sex');
+  };
+
+  const handleAbdomenStatusSelect = (newAbdomenStatus?: string) => {
+    annotationForm.setValue('abdomenStatus', newAbdomenStatus, {
+      shouldDirty: true,
+    });
+
+    annotationForm.clearErrors('abdomenStatus');
+  };
+
+  const handleFlagged = (
+    newFlagged: boolean,
+    updateFormValue: (value: boolean) => void,
+  ) => {
+    updateFormValue(newFlagged);
+
+    if (newFlagged) {
+      annotationForm.clearErrors(['species', 'sex', 'abdomenStatus']);
+    } else {
+      annotationForm.clearErrors(['notes']);
+    }
+  };
+
+  const handleValidSubmit = (formInput: AnnotationFormInput) => {
+    if (typeof onSubmit === 'function') {
+      return onSubmit(formInput);
+    }
+    console.warn('onSubmit prop not provided - Data:', formInput);
+  };
+
+  return (
+    <Form {...annotationForm}>
+      <form
+        onSubmit={annotationForm.handleSubmit(handleValidSubmit)}
+        className={cn('space-y-3', className)}
+      >
+        <fieldset
+          disabled={annotationForm.formState.isSubmitting}
+          className="space-y-3"
+        >
+          <FormField
+            control={annotationForm.control}
+            name="species"
+            render={({ field, fieldState }) => (
+              <FormItem>
+                <FormLabel htmlFor={toDomId(field.name)} className="m-0">
+                  Species
+                </FormLabel>
+                <FormControl>
+                  <MorphIdSelectMenu
+                    label="species"
+                    morphIds={Object.values(SPECIES_MORPH_IDS)}
+                    selectedMorphId={field.value}
+                    onMorphSelect={handleSpeciesSelect}
+                    inValid={!!fieldState.error}
+                  />
+                </FormControl>
+                <FormMessage className="text-xs" />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={annotationForm.control}
+            name="sex"
+            render={({ field, fieldState }) => (
+              <FormItem>
+                <FormLabel htmlFor={toDomId(field.name)} className="m-0">
+                  Sex
+                </FormLabel>
+                <FormControl>
+                  <MorphIdSelectMenu
+                    label="Sex"
+                    morphIds={Object.values(SEX_MORPH_IDS)}
+                    selectedMorphId={field.value}
+                    onMorphSelect={handleSexSelect}
+                    inValid={!!fieldState.error && sexEnabled}
+                    disabled={!sexEnabled}
+                  />
+                </FormControl>
+                <FormMessage className="text-xs" />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={annotationForm.control}
+            name="abdomenStatus"
+            render={({ field, fieldState }) => (
+              <FormItem>
+                <FormLabel htmlFor={toDomId(field.name)} className="m-0">
+                  Abdomen Status
+                </FormLabel>
+                <FormControl>
+                  <MorphIdSelectMenu
+                    label="Abdomen Status"
+                    morphIds={Object.values(ABDOMEN_STATUS_MORPH_IDS)}
+                    selectedMorphId={field.value}
+                    onMorphSelect={handleAbdomenStatusSelect}
+                    inValid={!!fieldState.error && abdomenStatusEnabled}
+                    disabled={!abdomenStatusEnabled}
+                  />
+                </FormControl>
+                <FormMessage className="text-xs" />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={annotationForm.control}
+            name="notes"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel htmlFor={toDomId(field.name)} className="m-0">
+                  Notes
+                  {isFlagged && (
+                    <span className="text-destructive">(Required)*</span>
+                  )}
+                </FormLabel>
+                <FormControl>
+                  <Textarea
+                    id={toDomId(field.name)}
+                    className="h-[70px] resize-none overflow-y-auto text-sm"
+                    placeholder="Add observations..."
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div className="flex gap-3 pt-2">
+            <FormField
+              control={annotationForm.control}
+              name="flagged"
+              render={({ field }) => (
+                <Toggle
+                  pressed={field.value}
+                  onPressedChange={newFlagged =>
+                    handleFlagged(newFlagged, field.onChange)
+                  }
+                  variant="outline"
+                  disabled={annotationForm.formState.isSubmitting}
+                  className={cn(
+                    'flex-1',
+                    'flex items-center justify-center gap-1.5 rounded-md border transition-colors',
+                    'data-[state=on]:bg-destructive/10 data-[state=on]:text-destructive data-[state=on]:border-destructive data-[state=on]:hover:bg-destructive/20 motion-safe:data-[state=on]:animate-pulse',
+                    'data-[state=off]:bg-background data-[state=off]:border-input data-[state=off]:hover:bg-accent data-[state=off]:hover:text-accent-foreground',
+                  )}
+                >
+                  <Flag
+                    className={cn(
+                      'h-4 w-4',
+                      field.value
+                        ? 'text-destructive'
+                        : 'text-muted-foreground',
+                    )}
+                  />
+                  {field.value ? 'Specimen Flagged' : 'Flag Specimen'}
+                </Toggle>
+              )}
+            />
+
+            <Button
+              type="submit"
+              className="flex flex-1 items-center justify-center gap-1.5"
+              disabled={annotationForm.formState.isSubmitting}
+            >
+              <Save className="h-4 w-4" />
+              {annotationForm.formState.isSubmitting
+                ? 'Submitting...'
+                : 'Submit'}
+            </Button>
+          </div>
+        </fieldset>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/annotate/task-detail/annotation-form-panel/annotation-form.tsx
+++ b/src/components/annotate/task-detail/annotation-form-panel/annotation-form.tsx
@@ -33,7 +33,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { showSuccessToast } from '@/lib/shared/ui/show-success-toast';
 
 interface AnnotationFormProps {
-  className?: string;
   annotationId: number;
   defaultValues: {
     species?: string;
@@ -45,7 +44,6 @@ interface AnnotationFormProps {
 }
 
 export function AnnotationForm({
-  className = '',
   annotationId,
   defaultValues,
 }: AnnotationFormProps) {
@@ -54,8 +52,8 @@ export function AnnotationForm({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['annotations'] });
       queryClient.invalidateQueries({ queryKey: ['annotation-task-progress'] });
-      showSuccessToast("Annotation submitted successfully.");
-    }
+      showSuccessToast('Annotation submitted successfully.');
+    },
   });
 
   const annotationForm = useForm<AnnotationFormInput>({
@@ -139,7 +137,7 @@ export function AnnotationForm({
     <Form {...annotationForm}>
       <form
         onSubmit={annotationForm.handleSubmit(handleValidSubmit)}
-        className={cn('space-y-3', className)}
+        className="space-y-3"
       >
         <fieldset
           disabled={updateAnnotationMutation.isPending}

--- a/src/components/annotate/task-detail/annotation-form-panel/annotation-form.tsx
+++ b/src/components/annotate/task-detail/annotation-form-panel/annotation-form.tsx
@@ -22,7 +22,7 @@ import { Button } from '@/components/ui/button';
 import { Toggle } from '@/components/ui/toggle';
 import { Flag, Save } from 'lucide-react';
 import { toDomId } from '@/lib/shared/utils/dom';
-import MorphIdSelectMenu from '../annotation-form-panel/morph-id-select-menu';
+import MorphIdSelectMenu from './morph-id-select-menu';
 import {
   SPECIES_MORPH_IDS,
   SEX_MORPH_IDS,
@@ -33,7 +33,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { showSuccessToast } from '@/lib/shared/ui/show-success-toast';
 
 interface AnnotationFormProps {
-  className?: string;
   annotationId: number;
   defaultValues: {
     species?: string;
@@ -45,7 +44,6 @@ interface AnnotationFormProps {
 }
 
 export function AnnotationForm({
-  className = '',
   annotationId,
   defaultValues,
 }: AnnotationFormProps) {
@@ -82,28 +80,28 @@ export function AnnotationForm({
   );
 
   const handleSpeciesSelect = (newSpecies?: string) => {
-    annotationForm.setValue('species', newSpecies || '', { shouldDirty: true });
+    annotationForm.setValue('species', newSpecies ?? undefined, { shouldDirty: true });
 
     if (!isSexEnabled(newSpecies)) {
-      annotationForm.setValue('sex', '', { shouldDirty: true });
-      annotationForm.setValue('abdomenStatus', '', { shouldDirty: true });
+      annotationForm.setValue('sex', undefined, { shouldDirty: true });
+      annotationForm.setValue('abdomenStatus', undefined, { shouldDirty: true });
       annotationForm.clearErrors(['sex', 'abdomenStatus']);
     }
     annotationForm.clearErrors('species');
   };
 
   const handleSexSelect = (newSex?: string) => {
-    annotationForm.setValue('sex', newSex || '', { shouldDirty: true });
+    annotationForm.setValue('sex', newSex ?? undefined, { shouldDirty: true });
 
     if (!isAbdomenStatusEnabled(selectedSpecies, newSex)) {
-      annotationForm.setValue('abdomenStatus', '', { shouldDirty: true });
+      annotationForm.setValue('abdomenStatus', undefined, { shouldDirty: true });
       annotationForm.clearErrors(['abdomenStatus']);
     }
     annotationForm.clearErrors('sex');
   };
 
   const handleAbdomenStatusSelect = (newAbdomenStatus?: string) => {
-    annotationForm.setValue('abdomenStatus', newAbdomenStatus || '', {
+    annotationForm.setValue('abdomenStatus', newAbdomenStatus ?? undefined, {
       shouldDirty: true,
     });
     annotationForm.clearErrors('abdomenStatus');
@@ -139,7 +137,7 @@ export function AnnotationForm({
     <Form {...annotationForm}>
       <form
         onSubmit={annotationForm.handleSubmit(handleValidSubmit)}
-        className={cn('space-y-3', className)}
+        className={'space-y-3'}
       >
         <fieldset
           disabled={updateAnnotationMutation.isPending}

--- a/src/components/annotate/task-detail/annotation-form-panel/annotation-form.tsx
+++ b/src/components/annotate/task-detail/annotation-form-panel/annotation-form.tsx
@@ -22,7 +22,7 @@ import { Button } from '@/components/ui/button';
 import { Toggle } from '@/components/ui/toggle';
 import { Flag, Save } from 'lucide-react';
 import { toDomId } from '@/lib/shared/utils/dom';
-import MorphIdSelectMenu from './morph-id-select-menu';
+import MorphIdSelectMenu from '../annotation-form-panel/morph-id-select-menu';
 import {
   SPECIES_MORPH_IDS,
   SEX_MORPH_IDS,
@@ -33,6 +33,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { showSuccessToast } from '@/lib/shared/ui/show-success-toast';
 
 interface AnnotationFormProps {
+  className?: string;
   annotationId: number;
   defaultValues: {
     species?: string;
@@ -44,6 +45,7 @@ interface AnnotationFormProps {
 }
 
 export function AnnotationForm({
+  className = '',
   annotationId,
   defaultValues,
 }: AnnotationFormProps) {
@@ -80,28 +82,28 @@ export function AnnotationForm({
   );
 
   const handleSpeciesSelect = (newSpecies?: string) => {
-    annotationForm.setValue('species', newSpecies ?? undefined, { shouldDirty: true });
+    annotationForm.setValue('species', newSpecies || '', { shouldDirty: true });
 
     if (!isSexEnabled(newSpecies)) {
-      annotationForm.setValue('sex', undefined, { shouldDirty: true });
-      annotationForm.setValue('abdomenStatus', undefined, { shouldDirty: true });
+      annotationForm.setValue('sex', '', { shouldDirty: true });
+      annotationForm.setValue('abdomenStatus', '', { shouldDirty: true });
       annotationForm.clearErrors(['sex', 'abdomenStatus']);
     }
     annotationForm.clearErrors('species');
   };
 
   const handleSexSelect = (newSex?: string) => {
-    annotationForm.setValue('sex', newSex ?? undefined, { shouldDirty: true });
+    annotationForm.setValue('sex', newSex || '', { shouldDirty: true });
 
     if (!isAbdomenStatusEnabled(selectedSpecies, newSex)) {
-      annotationForm.setValue('abdomenStatus', undefined, { shouldDirty: true });
+      annotationForm.setValue('abdomenStatus', '', { shouldDirty: true });
       annotationForm.clearErrors(['abdomenStatus']);
     }
     annotationForm.clearErrors('sex');
   };
 
   const handleAbdomenStatusSelect = (newAbdomenStatus?: string) => {
-    annotationForm.setValue('abdomenStatus', newAbdomenStatus ?? undefined, {
+    annotationForm.setValue('abdomenStatus', newAbdomenStatus || '', {
       shouldDirty: true,
     });
     annotationForm.clearErrors('abdomenStatus');
@@ -137,7 +139,7 @@ export function AnnotationForm({
     <Form {...annotationForm}>
       <form
         onSubmit={annotationForm.handleSubmit(handleValidSubmit)}
-        className={'space-y-3'}
+        className={cn('space-y-3', className)}
       >
         <fieldset
           disabled={updateAnnotationMutation.isPending}

--- a/src/components/annotate/task-detail/annotation-form-panel/morph-id-select-menu.tsx
+++ b/src/components/annotate/task-detail/annotation-form-panel/morph-id-select-menu.tsx
@@ -26,11 +26,9 @@ export default function MorphIdSelectMenu({
   disabled,
   inValid,
 }: MorphIdSelectMenuProps) {
-  const value = selectedMorphId || '';
-
   return (
     <Select
-      value={value}
+      value={selectedMorphId}
       onValueChange={value =>
         onMorphSelect(value === 'clear' ? undefined : value)
       }

--- a/src/components/annotate/task-detail/annotation-form-panel/morph-id-select-menu.tsx
+++ b/src/components/annotate/task-detail/annotation-form-panel/morph-id-select-menu.tsx
@@ -28,7 +28,7 @@ export default function MorphIdSelectMenu({
 }: MorphIdSelectMenuProps) {
   return (
     <Select
-      value={selectedMorphId || ''}
+      value={selectedMorphId}
       onValueChange={value =>
         onMorphSelect(value === 'clear' ? undefined : value)
       }

--- a/src/components/annotate/task-detail/annotation-form-panel/morph-id-select-menu.tsx
+++ b/src/components/annotate/task-detail/annotation-form-panel/morph-id-select-menu.tsx
@@ -28,7 +28,7 @@ export default function MorphIdSelectMenu({
 }: MorphIdSelectMenuProps) {
   return (
     <Select
-      value={selectedMorphId}
+      value={selectedMorphId || ''}
       onValueChange={value =>
         onMorphSelect(value === 'clear' ? undefined : value)
       }

--- a/src/components/annotate/task-detail/annotation-form-panel/morph-id-select-menu.tsx
+++ b/src/components/annotate/task-detail/annotation-form-panel/morph-id-select-menu.tsx
@@ -26,9 +26,11 @@ export default function MorphIdSelectMenu({
   disabled,
   inValid,
 }: MorphIdSelectMenuProps) {
+  const value = selectedMorphId || '';
+
   return (
     <Select
-      value={selectedMorphId || ''}
+      value={value}
       onValueChange={value =>
         onMorphSelect(value === 'clear' ? undefined : value)
       }
@@ -42,13 +44,7 @@ export default function MorphIdSelectMenu({
             'border-destructive focus:border-destructive focus:ring-destructive',
         )}
       >
-        <SelectValue placeholder={`Select ${label}...`}>
-          {selectedMorphId ? (
-            <span> {selectedMorphId} </span>
-          ) : (
-            <span className="text-muted-foreground">Select {label}...</span>
-          )}
-        </SelectValue>
+        <SelectValue placeholder={`Select ${label}...`} />
       </SelectTrigger>
       <SelectContent align="start" className="max-h-100 w-full overflow-y-auto">
         {morphIds.map(morphId => (
@@ -60,10 +56,10 @@ export default function MorphIdSelectMenu({
         <SelectSeparator />
         <SelectItem
           value="clear"
-          disabled={selectedMorphId === undefined}
+          disabled={!selectedMorphId}
           className={cn(
             'text-destructive focus:text-destructive focus:bg-destructive/10',
-            selectedMorphId === undefined && 'pointer-events-none opacity-50',
+            !selectedMorphId && 'pointer-events-none opacity-50',
           )}
         >
           Remove selection

--- a/src/components/annotate/task-detail/annotation-form-panel/morph-id-select-menu.tsx
+++ b/src/components/annotate/task-detail/annotation-form-panel/morph-id-select-menu.tsx
@@ -1,79 +1,74 @@
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue, SelectSeparator } from '@/components/ui/select';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SelectSeparator,
+} from '@/components/ui/select';
 import { cn } from '@/lib/utils';
 import { toDomId } from '@/lib/shared/utils/dom';
 
-
 interface MorphIdSelectMenuProps {
-    label: string;
-    morphIds: readonly string[];
-    selectedMorphId: string | undefined;
-    onMorphSelect: (morphId?: string) => void;
-    disabled?: boolean;
-    inValid?: boolean;
+  label: string;
+  morphIds: readonly string[];
+  selectedMorphId: string | undefined;
+  onMorphSelect: (morphId?: string) => void;
+  disabled?: boolean;
+  inValid?: boolean;
 }
 
 export default function MorphIdSelectMenu({
-    label,
-    morphIds,
-    selectedMorphId,
-    onMorphSelect,
-    disabled,
-    inValid,
+  label,
+  morphIds,
+  selectedMorphId,
+  onMorphSelect,
+  disabled,
+  inValid,
 }: MorphIdSelectMenuProps) {
-    return (
-        <Select
-            value={selectedMorphId || ""}
-            onValueChange={(value) => onMorphSelect(value === "clear" ? undefined : value)}
-            disabled={disabled}
+  return (
+    <Select
+      value={selectedMorphId || ''}
+      onValueChange={value =>
+        onMorphSelect(value === 'clear' ? undefined : value)
+      }
+      disabled={disabled}
+    >
+      <SelectTrigger
+        id={toDomId(label)}
+        className={cn(
+          'w-full',
+          inValid &&
+            'border-destructive focus:border-destructive focus:ring-destructive',
+        )}
+      >
+        <SelectValue placeholder={`Select ${label}...`}>
+          {selectedMorphId ? (
+            <span> {selectedMorphId} </span>
+          ) : (
+            <span className="text-muted-foreground">Select {label}...</span>
+          )}
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent align="start" className="max-h-100 w-full overflow-y-auto">
+        {morphIds.map(morphId => (
+          <SelectItem key={morphId} value={morphId}>
+            {morphId}
+          </SelectItem>
+        ))}
+
+        <SelectSeparator />
+        <SelectItem
+          value="clear"
+          disabled={selectedMorphId === undefined}
+          className={cn(
+            'text-destructive focus:text-destructive focus:bg-destructive/10',
+            selectedMorphId === undefined && 'pointer-events-none opacity-50',
+          )}
         >
-            <SelectTrigger 
-            id={toDomId(label)}
-            className= {cn(
-                "w-full",
-                inValid && "border-destructive focus:border-destructive focus:ring-destructive"
-            )}
-            >
-                <SelectValue
-                    placeholder={`Select ${label}...`}
-                >
-                    {selectedMorphId ? (
-                        <span> {selectedMorphId} </span>
-                    ) : (
-                        <span className="text-muted-foreground">Select {label}...</span>
-                    )}
-
-                </SelectValue>
-
-            </SelectTrigger>
-            <SelectContent
-                align="start"
-                className="w-full max-h-100 overflow-y-auto"
-            >
-                {morphIds.map((morphId) => (
-                    <SelectItem
-                        key={morphId}
-                        value={morphId}
-                    >
-                        {morphId}
-                    </SelectItem>
-                ))}
-
-                <SelectSeparator />
-                <SelectItem
-                    value="clear"
-                    disabled={selectedMorphId === undefined}
-                    className={cn(
-                        "text-destructive focus:text-destructive focus:bg-destructive/10",
-                        selectedMorphId === undefined && "pointer-events-none opacity-50"
-                    )}
-                >
-                    Remove selection
-                </SelectItem>
-            </SelectContent>
-        </Select>
-
-    )
+          Remove selection
+        </SelectItem>
+      </SelectContent>
+    </Select>
+  );
 }
-
-
-

--- a/src/components/annotate/task-detail/annotation-form-panel/morph-id-select-menu.tsx
+++ b/src/components/annotate/task-detail/annotation-form-panel/morph-id-select-menu.tsx
@@ -26,9 +26,11 @@ export default function MorphIdSelectMenu({
   disabled,
   inValid,
 }: MorphIdSelectMenuProps) {
+  const value = selectedMorphId || '';
+
   return (
     <Select
-      value={selectedMorphId}
+      value={value}
       onValueChange={value =>
         onMorphSelect(value === 'clear' ? undefined : value)
       }

--- a/src/components/annotate/task-detail/annotation-form-panel/task-progress-breakdown.tsx
+++ b/src/components/annotate/task-detail/annotation-form-panel/task-progress-breakdown.tsx
@@ -3,15 +3,12 @@ import { AnnotationTaskProgress } from '@/lib/entities/annotation';
 import { AlertTriangle, CheckCircle, Clock } from 'lucide-react';
 import { Fragment } from 'react';
 
-
-
 interface TaskProgressBreakdownProps {
   taskProgress?: AnnotationTaskProgress;
 }
 
 export function TaskProgressBreakdown({
   taskProgress,
-
 }: TaskProgressBreakdownProps) {
   const totalCount = taskProgress?.total ?? 0;
   const annotatedCount = taskProgress?.annotated ?? 0;
@@ -21,7 +18,6 @@ export function TaskProgressBreakdown({
     totalCount - (annotatedCount + flaggedCount),
   );
   const progressPercent = taskProgress?.percent ?? 0;
-
 
   return (
     <Fragment>
@@ -76,7 +72,6 @@ export function TaskProgressBreakdown({
           </div>
         </div>
       </div>
-
     </Fragment>
   );
 }

--- a/src/components/annotate/task-detail/annotation-form-panel/validation/annotation-form-schema.ts
+++ b/src/components/annotate/task-detail/annotation-form-panel/validation/annotation-form-schema.ts
@@ -47,7 +47,6 @@ export const annotationFormSchema = AnnotationBase.superRefine(
         path: ['species'],
         message: 'Species is required when the specimen is not flagged.',
       });
-      return;
     }
 
     if (isSexEnabled(formFields.species)) {

--- a/src/components/annotate/task-detail/annotation-form-panel/validation/annotation-form-schema.ts
+++ b/src/components/annotate/task-detail/annotation-form-panel/validation/annotation-form-schema.ts
@@ -1,15 +1,20 @@
 import {
-    SPECIES_MORPH_IDS,
-    SEX_MORPH_IDS,
-    ABDOMEN_STATUS_MORPH_IDS,
+  SPECIES_MORPH_IDS,
+  SEX_MORPH_IDS,
+  ABDOMEN_STATUS_MORPH_IDS,
 } from '@/lib/entities/specimen/morph-ids';
-import { spec } from 'node:test/reporters';
 
 import { z } from 'zod';
 
-const SPECIES_VALUES = Object.values(SPECIES_MORPH_IDS) as [string, ... string[]];
-const SEX_VALUES = Object.values(SEX_MORPH_IDS) as [string, ... string[]];
-const ABDOMEN_STATUS_VALUES = Object.values(ABDOMEN_STATUS_MORPH_IDS) as [string, ... string[]];
+const SPECIES_VALUES = Object.values(SPECIES_MORPH_IDS) as [
+  string,
+  ...string[],
+];
+const SEX_VALUES = Object.values(SEX_MORPH_IDS) as [string, ...string[]];
+const ABDOMEN_STATUS_VALUES = Object.values(ABDOMEN_STATUS_MORPH_IDS) as [
+  string,
+  ...string[],
+];
 
 export const AnnotationBase = z.object({
   species: z.enum(SPECIES_VALUES).optional(),
@@ -18,65 +23,56 @@ export const AnnotationBase = z.object({
   notes: z.string().optional(),
   flagged: z.boolean().default(false),
 });
-export const isSexEnabled = (species?: string) => 
-    species !== SPECIES_MORPH_IDS.NON_MOSQUITO;
+export const isSexEnabled = (species?: string) =>
+  species !== SPECIES_MORPH_IDS.NON_MOSQUITO;
 export const isAbdomenStatusEnabled = (species?: string, sex?: string) =>
-    isSexEnabled(species) && sex !== SEX_MORPH_IDS.MALE;
+  isSexEnabled(species) && sex !== SEX_MORPH_IDS.MALE;
 
 export const annotationFormSchema = AnnotationBase.superRefine(
-    (formFields, context) => {
-        if (formFields.flagged) {
-            if (!formFields.notes || formFields.notes.trim().length === 0) {
-                context.addIssue({
-                    code: "custom",
-                    path: ["notes"],
-                    message: "Notes are required when the specimen is flagged.",
-                });
-            }
-            return;
-        }
-        if (!formFields.species) {
-            context.addIssue({
-                code: "custom",
-                path: ["species"],
-                message: "Species is required when the specimen is not flagged.",
-            });
-        }
-
-        if (formFields.species === SPECIES_MORPH_IDS.NON_MOSQUITO) {
-            return;
-        }
-
-
-
-        if (!formFields.sex) {
-            context.addIssue({
-                code: "custom",
-                path: ["sex"],
-                message: "Sex is required when the specimen is not flagged.",
-            });
-        }
-
-
-
-        if (formFields.sex === SEX_MORPH_IDS.MALE) {
-            return;
-        }
-
- 
-
-        if (!formFields.abdomenStatus) {
-            context.addIssue({
-                code: "custom",
-                path: ["abdomenStatus"],
-                message: "Abdomen status is required when the specimen is not flagged.",
-            });
-        }
-
-
-
+  (formFields, context) => {
+    if (formFields.flagged) {
+      if (!formFields.notes || formFields.notes.trim().length === 0) {
+        context.addIssue({
+          code: 'custom',
+          path: ['notes'],
+          message: 'Notes are required when the specimen is flagged.',
+        });
+      }
+      return;
     }
-)
+    if (!formFields.species) {
+      context.addIssue({
+        code: 'custom',
+        path: ['species'],
+        message: 'Species is required when the specimen is not flagged.',
+      });
+    }
+
+    if (formFields.species === SPECIES_MORPH_IDS.NON_MOSQUITO) {
+      return;
+    }
+
+    if (!formFields.sex) {
+      context.addIssue({
+        code: 'custom',
+        path: ['sex'],
+        message: 'Sex is required when the specimen is not flagged.',
+      });
+    }
+
+    if (formFields.sex === SEX_MORPH_IDS.MALE) {
+      return;
+    }
+
+    if (!formFields.abdomenStatus) {
+      context.addIssue({
+        code: 'custom',
+        path: ['abdomenStatus'],
+        message: 'Abdomen status is required when the specimen is not flagged.',
+      });
+    }
+  },
+);
 
 export type AnnotationFormInput = z.input<typeof annotationFormSchema>;
 export type AnnotationFormOutput = z.output<typeof annotationFormSchema>;

--- a/src/components/annotate/task-detail/page-client.tsx
+++ b/src/components/annotate/task-detail/page-client.tsx
@@ -11,120 +11,25 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import {
-  annotationFormSchema,
-  AnnotationFormOutput,
-  AnnotationFormInput,
-  isAbdomenStatusEnabled,
-  isSexEnabled,
-} from './annotation-form-panel/validation/annotation-form-schema';
-import {
   useAnnotationTaskProgressQuery,
   useTaskAnnotationsQuery,
 } from '@/lib/annotate/client';
-import { Toggle } from '@/components/ui/toggle';
-import { cn } from '@/lib/utils';
-import { Textarea } from '@/components/ui/textarea';
 import { formatDate } from '@/lib/shared/utils/date';
-import {
-  ArrowLeft,
-  ArrowRight,
-  CalendarDays,
-  Info,
-  Flag,
-  Save,
-} from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ArrowLeft, ArrowRight, CalendarDays } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
 import { TaskProgressBreakdown } from './annotation-form-panel/task-progress-breakdown';
 import { SpecimenMetadata } from './specimen-image-panel/specimen-metadata';
 import { SpecimenImageViewer } from './specimen-image-panel/specimen-image-viewer';
-import MorphIdSelectMenu from './annotation-form-panel/morph-id-select-menu';
-import {
-  SPECIES_MORPH_IDS,
-  SEX_MORPH_IDS,
-  ABDOMEN_STATUS_MORPH_IDS,
-} from '@/lib/entities/specimen/morph-ids';
-import { toDomId } from '@/lib/shared/utils/dom';
-import {
-  Form,
-  FormField,
-  FormControl,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
+import { AnnotationForm } from './annotation-form-panel/annotation-form';
+
 interface AnnotationTaskDetailPageClientProps {
   taskId: number;
-  onSubmit?: (values: AnnotationFormOutput) => Promise<void> | void;
-  className?: string;
 }
 
 export function AnnotationTaskDetailPageClient({
   taskId,
-  onSubmit,
-  className,
 }: AnnotationTaskDetailPageClientProps) {
   const [page, setPage] = useState(1);
-
-  const annotationForm = useForm<AnnotationFormInput>({
-    resolver: zodResolver(annotationFormSchema),
-    defaultValues: {
-      species: undefined,
-      sex: undefined,
-      abdomenStatus: undefined,
-      notes: undefined,
-      flagged: false,
-    },
-    mode: 'onSubmit',
-    reValidateMode: 'onChange',
-  });
-  const selectedSpecies = annotationForm.watch('species');
-  const selectedSex = annotationForm.watch('sex');
-  const selectedAbdomenStatus = annotationForm.watch('abdomenStatus');
-  const isFlagged = annotationForm.watch('flagged');
-
-  const sexEnabled = isSexEnabled(selectedSpecies);
-  const abdomenStatusEnabled = isAbdomenStatusEnabled(
-    selectedSpecies,
-    selectedSex,
-  );
-
-  const handleSpeciesSelect = (newSpecies?: string) => {
-    annotationForm.setValue('species', newSpecies, { shouldDirty: true });
-    if (!isSexEnabled(newSpecies)) {
-      annotationForm.setValue('sex', undefined, {
-        shouldDirty: true,
-        shouldValidate: false,
-      });
-      annotationForm.setValue('abdomenStatus', undefined, {
-        shouldDirty: true,
-        shouldValidate: false,
-      });
-      annotationForm.clearErrors(['sex', 'abdomenStatus']);
-    }
-    annotationForm.clearErrors('species');
-  };
-
-  const handleSexSelect = (newSex?: string) => {
-    annotationForm.setValue('sex', newSex, { shouldDirty: true });
-    if (!isAbdomenStatusEnabled(selectedSpecies, newSex)) {
-      annotationForm.setValue('abdomenStatus', undefined, {
-        shouldDirty: true,
-        shouldValidate: false,
-      });
-      annotationForm.clearErrors(['abdomenStatus']);
-    }
-    annotationForm.clearErrors('sex');
-  };
-
-  const handleAbdomenStatusSelect = (newAbdomenStatus?: string) => {
-    annotationForm.setValue('abdomenStatus', newAbdomenStatus, {
-      shouldDirty: true,
-    });
-
-    annotationForm.clearErrors('abdomenStatus');
-  };
 
   const {
     data: annotationsPage,
@@ -144,6 +49,7 @@ export function AnnotationTaskDetailPageClient({
     () => annotationsPage?.items?.[0] ?? null,
     [annotationsPage],
   );
+  const annotationStatus = currentAnnotation?.status ?? null;
 
   const imageUrl = useMemo(() => {
     const specimen = currentAnnotation?.specimen;
@@ -157,40 +63,17 @@ export function AnnotationTaskDetailPageClient({
     return `/api/bff${relativePath.startsWith('/') ? relativePath : `/${relativePath}`}`;
   }, [currentAnnotation]);
 
-  const handleFlagged = (
-    newFlagged: boolean,
-    updateFormValue: (value: boolean) => void,
-  ) => {
-    updateFormValue(newFlagged);
-
-    if (newFlagged) {
-      annotationForm.clearErrors(['species', 'sex', 'abdomenStatus']);
-    } else {
-      annotationForm.clearErrors(['notes']);
-    }
-  };
-
   const handleNext = useCallback(() => {
     if (hasMore && !isFetching && !isLoading) {
       setPage(prev => prev + 1);
-      annotationForm.reset();
     }
   }, [hasMore, isFetching, isLoading]);
 
   const handlePrevious = useCallback(() => {
     if (page > 1 && !isFetching && !isLoading) {
       setPage(prev => Math.max(prev - 1, 1));
-      annotationForm.reset();
     }
   }, [page, isFetching, isLoading]);
-
-  const handleValidSubmit = (formInput: AnnotationFormInput) => {
-    const validatedFormOutput = annotationFormSchema.parse(formInput);
-    if (typeof onSubmit === 'function') {
-      return onSubmit(validatedFormOutput);
-    }
-    console.warn('onSubmit prop not provided - Data:', validatedFormOutput);
-  };
 
   const createdAt = currentAnnotation?.createdAt
     ? formatDate(currentAnnotation.createdAt).monthYear
@@ -213,6 +96,11 @@ export function AnnotationTaskDetailPageClient({
           <div className="flex flex-wrap items-center justify-between gap-3">
             <CardTitle className="text-lg font-semibold">
               Specimen Image {totalImages ? `(${page} of ${totalImages})` : ''}
+              {annotationStatus && (
+                <Badge variant="outline" className="ml-5">
+                  {annotationStatus}
+                </Badge>
+              )}
             </CardTitle>
             {createdAt && (
               <Badge
@@ -246,192 +134,31 @@ export function AnnotationTaskDetailPageClient({
           </CardTitle>
           <TaskProgressBreakdown taskProgress={taskProgress} />
         </CardHeader>
-        <div>
-          <CardContent className="pt-0">
-            <Form {...annotationForm}>
-              <form
-                onSubmit={annotationForm.handleSubmit(handleValidSubmit)}
-                className={cn('space-y-3', className)}
-              >
-                <fieldset
-                  disabled={annotationForm.formState.isSubmitting}
-                  className="space-y-3"
-                >
-                  <FormField
-                    control={annotationForm.control}
-                    name="species"
-                    render={({ field, fieldState }) => (
-                      <FormItem>
-                        <FormLabel
-                          htmlFor={toDomId(field.name)}
-                          className="m-0"
-                        >
-                          Species
-                        </FormLabel>
-                        <FormControl>
-                          <MorphIdSelectMenu
-                            label="species"
-                            morphIds={Object.values(SPECIES_MORPH_IDS)}
-                            selectedMorphId={field.value}
-                            onMorphSelect={handleSpeciesSelect}
-                            inValid={!!fieldState.error}
-                          />
-                        </FormControl>
-                        <FormMessage className="text-xs" />
-                      </FormItem>
-                    )}
-                  />
 
-                  <FormField
-                    control={annotationForm.control}
-                    name="sex"
-                    render={({ field, fieldState }) => (
-                      <FormItem>
-                        <FormLabel
-                          htmlFor={toDomId(field.name)}
-                          className="m-0"
-                        >
-                          Sex
-                        </FormLabel>
-                        <FormControl>
-                          <MorphIdSelectMenu
-                            label="Sex"
-                            morphIds={Object.values(SEX_MORPH_IDS)}
-                            selectedMorphId={field.value}
-                            onMorphSelect={handleSexSelect}
-                            inValid={!!fieldState.error && sexEnabled}
-                            disabled={!sexEnabled}
-                          />
-                        </FormControl>
-                        <FormMessage className="text-xs" />
-                      </FormItem>
-                    )}
-                  />
+        <CardContent className="pt-0">
+          <AnnotationForm key={`annotation-form-${page}`} />
+        </CardContent>
 
-                  <FormField
-                    control={annotationForm.control}
-                    name="abdomenStatus"
-                    render={({ field, fieldState }) => (
-                      <FormItem>
-                        <FormLabel
-                          htmlFor={toDomId(field.name)}
-                          className="m-0"
-                        >
-                          Abdomen Status
-                        </FormLabel>
-                        <FormControl>
-                          <MorphIdSelectMenu
-                            label="Abdomen Status"
-                            morphIds={Object.values(ABDOMEN_STATUS_MORPH_IDS)}
-                            selectedMorphId={field.value}
-                            onMorphSelect={handleAbdomenStatusSelect}
-                            inValid={!!fieldState.error && abdomenStatusEnabled}
-                            disabled={!abdomenStatusEnabled}
-                          />
-                        </FormControl>
-                        <FormMessage className="text-xs" />
-                      </FormItem>
-                    )}
-                  />
-
-                  <FormField
-                    control={annotationForm.control}
-                    name="notes"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel
-                          htmlFor={toDomId(field.name)}
-                          className="m-0"
-                        >
-                          Notes
-                          {isFlagged && (
-                            <span className="text-destructive">
-                              (Required)*
-                            </span>
-                          )}
-                        </FormLabel>
-                        <FormControl>
-                          <Textarea
-                            id={toDomId(field.name)}
-                            className="h-[70px] resize-none overflow-y-auto text-sm"
-                            placeholder="Add observations..."
-                            {...field}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  <div className="flex gap-3 pt-2">
-                    <FormField
-                      control={annotationForm.control}
-                      name="flagged"
-                      render={({ field }) => (
-                        <Toggle
-                          pressed={field.value}
-                          onPressedChange={newFlagged =>
-                            handleFlagged(newFlagged, field.onChange)
-                          }
-                          variant="outline"
-                          disabled={annotationForm.formState.isSubmitting}
-                          className={cn(
-                            'flex-1',
-                            'flex items-center justify-center gap-1.5 rounded-md border transition-colors',
-                            'data-[state=on]:bg-destructive/10 data-[state=on]:text-destructive data-[state=on]:border-destructive data-[state=on]:hover:bg-destructive/20 motion-safe:data-[state=on]:animate-pulse',
-                            'data-[state=off]:bg-background data-[state=off]:border-input data-[state=off]:hover:bg-accent data-[state=off]:hover:text-accent-foreground',
-                          )}
-                        >
-                          <Flag
-                            className={cn(
-                              'h-4 w-4',
-                              field.value
-                                ? 'text-destructive'
-                                : 'text-muted-foreground',
-                            )}
-                          />
-                          {field.value ? 'Specimen Flagged' : 'Flag Specimen'}
-                        </Toggle>
-                      )}
-                    />
-
-                    <Button
-                      type="submit"
-                      className="flex flex-1 items-center justify-center gap-1.5"
-                      disabled={annotationForm.formState.isSubmitting}
-                    >
-                      <Save className="h-4 w-4" />
-                      {annotationForm.formState.isSubmitting
-                        ? 'Submitting...'
-                        : 'Submit'}
-                    </Button>
-                  </div>
-
-                  <CardFooter className="mt-auto flex flex-wrap items-center justify-between gap-3 px-6 py-4">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      className="min-w-[120px]"
-                      onClick={handlePrevious}
-                      disabled={page === 1 || isFetching || isLoading}
-                    >
-                      <ArrowLeft className="mr-2 h-4 w-4" /> Previous
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      className="min-w-[120px]"
-                      onClick={handleNext}
-                      disabled={!hasMore || isFetching || isLoading}
-                    >
-                      Next <ArrowRight className="ml-2 h-4 w-4" />
-                    </Button>
-                  </CardFooter>
-                </fieldset>
-              </form>
-            </Form>
-          </CardContent>
-        </div>
+        <CardFooter className="mt-auto flex flex-wrap items-center justify-between gap-3 px-6 py-4">
+          <Button
+            type="button"
+            variant="outline"
+            className="min-w-[120px]"
+            onClick={handlePrevious}
+            disabled={page === 1 || isFetching || isLoading}
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" /> Previous
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            className="min-w-[120px]"
+            onClick={handleNext}
+            disabled={!hasMore || isFetching || isLoading}
+          >
+            Next <ArrowRight className="ml-2 h-4 w-4" />
+          </Button>
+        </CardFooter>
       </Card>
     </div>
   );

--- a/src/components/annotate/task-detail/page-client.tsx
+++ b/src/components/annotate/task-detail/page-client.tsx
@@ -136,7 +136,24 @@ export function AnnotationTaskDetailPageClient({
         </CardHeader>
 
         <CardContent className="pt-0">
-          <AnnotationForm key={`annotation-form-${page}`} />
+          {currentAnnotation ? (
+            <AnnotationForm
+              key={`annotation-${currentAnnotation.id}`}
+              annotationId={currentAnnotation.id}
+              defaultValues={{
+                species: currentAnnotation.morphSpecies ?? undefined,
+                sex: currentAnnotation.morphSex ?? undefined,
+                abdomenStatus:
+                  currentAnnotation.morphAbdomenStatus ?? undefined,
+                notes: currentAnnotation.notes ?? undefined,
+                flagged: currentAnnotation.status === 'FLAGGED',
+              }}
+            />
+          ) : (
+            <div className="text-muted-foreground flex h-32 items-center justify-center">
+              Loading annotation...
+            </div>
+          )}
         </CardContent>
 
         <CardFooter className="mt-auto flex flex-wrap items-center justify-between gap-3 px-6 py-4">

--- a/src/components/annotate/task-detail/page-client.tsx
+++ b/src/components/annotate/task-detail/page-client.tsx
@@ -10,7 +10,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { 
+import {
   annotationFormSchema,
   AnnotationFormOutput,
   AnnotationFormInput,
@@ -25,7 +25,14 @@ import { Toggle } from '@/components/ui/toggle';
 import { cn } from '@/lib/utils';
 import { Textarea } from '@/components/ui/textarea';
 import { formatDate } from '@/lib/shared/utils/date';
-import { ArrowLeft, ArrowRight, CalendarDays, Info, Flag, Save } from 'lucide-react';
+import {
+  ArrowLeft,
+  ArrowRight,
+  CalendarDays,
+  Info,
+  Flag,
+  Save,
+} from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { TaskProgressBreakdown } from './annotation-form-panel/task-progress-breakdown';
 import { SpecimenMetadata } from './specimen-image-panel/specimen-metadata';
@@ -38,11 +45,11 @@ import {
 } from '@/lib/entities/specimen/morph-ids';
 import { toDomId } from '@/lib/shared/utils/dom';
 import {
-  Form,  
+  Form,
   FormField,
-  FormControl, 
-  FormItem, 
-  FormLabel, 
+  FormControl,
+  FormItem,
+  FormLabel,
   FormMessage,
 } from '@/components/ui/form';
 import { useForm } from 'react-hook-form';
@@ -69,8 +76,8 @@ export function AnnotationTaskDetailPageClient({
       notes: undefined,
       flagged: false,
     },
-    mode: "onSubmit",
-    reValidateMode: "onChange",
+    mode: 'onSubmit',
+    reValidateMode: 'onChange',
   });
   const selectedSpecies = annotationForm.watch('species');
   const selectedSex = annotationForm.watch('sex');
@@ -78,41 +85,46 @@ export function AnnotationTaskDetailPageClient({
   const isFlagged = annotationForm.watch('flagged');
 
   const sexEnabled = isSexEnabled(selectedSpecies);
-  const abdomenStatusEnabled = isAbdomenStatusEnabled(selectedSpecies, selectedSex);
+  const abdomenStatusEnabled = isAbdomenStatusEnabled(
+    selectedSpecies,
+    selectedSex,
+  );
 
   const handleSpeciesSelect = (newSpecies?: string) => {
-    annotationForm.setValue("species", newSpecies, {shouldDirty: true});
+    annotationForm.setValue('species', newSpecies, { shouldDirty: true });
     if (!isSexEnabled(newSpecies)) {
-      annotationForm.setValue("sex", undefined, {
+      annotationForm.setValue('sex', undefined, {
         shouldDirty: true,
-        shouldValidate: false
+        shouldValidate: false,
       });
-      annotationForm.setValue("abdomenStatus", undefined, {
+      annotationForm.setValue('abdomenStatus', undefined, {
         shouldDirty: true,
-        shouldValidate: false
+        shouldValidate: false,
       });
-      annotationForm.clearErrors(["sex", "abdomenStatus"]);
+      annotationForm.clearErrors(['sex', 'abdomenStatus']);
     }
-    annotationForm.clearErrors("species");
-  }
+    annotationForm.clearErrors('species');
+  };
 
   const handleSexSelect = (newSex?: string) => {
-    annotationForm.setValue("sex", newSex, {shouldDirty: true});
+    annotationForm.setValue('sex', newSex, { shouldDirty: true });
     if (!isAbdomenStatusEnabled(selectedSpecies, newSex)) {
-      annotationForm.setValue("abdomenStatus", undefined, {
+      annotationForm.setValue('abdomenStatus', undefined, {
         shouldDirty: true,
-        shouldValidate: false
+        shouldValidate: false,
       });
-      annotationForm.clearErrors(["abdomenStatus"]);
+      annotationForm.clearErrors(['abdomenStatus']);
     }
-    annotationForm.clearErrors("sex");
-  }
+    annotationForm.clearErrors('sex');
+  };
 
   const handleAbdomenStatusSelect = (newAbdomenStatus?: string) => {
-    annotationForm.setValue("abdomenStatus", newAbdomenStatus, {shouldDirty: true});
-    
-    annotationForm.clearErrors("abdomenStatus");
-  }
+    annotationForm.setValue('abdomenStatus', newAbdomenStatus, {
+      shouldDirty: true,
+    });
+
+    annotationForm.clearErrors('abdomenStatus');
+  };
 
   const {
     data: annotationsPage,
@@ -147,17 +159,16 @@ export function AnnotationTaskDetailPageClient({
 
   const handleFlagged = (
     newFlagged: boolean,
-    updateFormValue: (value: boolean) => void
+    updateFormValue: (value: boolean) => void,
   ) => {
     updateFormValue(newFlagged);
 
     if (newFlagged) {
-      annotationForm.clearErrors(["species", "sex", "abdomenStatus"])
+      annotationForm.clearErrors(['species', 'sex', 'abdomenStatus']);
     } else {
-      annotationForm.clearErrors(["notes"])
+      annotationForm.clearErrors(['notes']);
     }
-  }
-
+  };
 
   const handleNext = useCallback(() => {
     if (hasMore && !isFetching && !isLoading) {
@@ -181,7 +192,6 @@ export function AnnotationTaskDetailPageClient({
     console.warn('onSubmit prop not provided - Data:', validatedFormOutput);
   };
 
-
   const createdAt = currentAnnotation?.createdAt
     ? formatDate(currentAnnotation.createdAt).monthYear
     : null;
@@ -202,8 +212,7 @@ export function AnnotationTaskDetailPageClient({
         <CardHeader className="space-y-1.5">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <CardTitle className="text-lg font-semibold">
-              Specimen Image{' '}
-              {totalImages ? `(${page} of ${totalImages})` : ''}
+              Specimen Image {totalImages ? `(${page} of ${totalImages})` : ''}
             </CardTitle>
             {createdAt && (
               <Badge
@@ -237,168 +246,192 @@ export function AnnotationTaskDetailPageClient({
           </CardTitle>
           <TaskProgressBreakdown taskProgress={taskProgress} />
         </CardHeader>
-      <div>
-        <CardContent className = "pt-0">
-          <Form {...annotationForm}>
-            <form
-              onSubmit={annotationForm.handleSubmit(handleValidSubmit)}
-              className={cn("space-y-3", className)}
-            >
-              <fieldset
-                disabled={annotationForm.formState.isSubmitting}
-                className="space-y-3"
+        <div>
+          <CardContent className="pt-0">
+            <Form {...annotationForm}>
+              <form
+                onSubmit={annotationForm.handleSubmit(handleValidSubmit)}
+                className={cn('space-y-3', className)}
               >
-                <FormField
-                  control={annotationForm.control}
-                  name="species"
-                  render={({ field, fieldState }) => (
-                    <FormItem>
-                      <FormLabel htmlFor={toDomId(field.name)} className="m-0">Species</FormLabel>
-                      <FormControl>
-                        <MorphIdSelectMenu
-                          label="species"
-                          morphIds={Object.values(SPECIES_MORPH_IDS)}
-                          selectedMorphId={field.value}
-                          onMorphSelect={handleSpeciesSelect}
-                          inValid={!!fieldState.error}
-                        />
-                      </FormControl>
-                      <FormMessage className="text-xs" />
-                    </FormItem>
-                  )}
-                />
+                <fieldset
+                  disabled={annotationForm.formState.isSubmitting}
+                  className="space-y-3"
+                >
+                  <FormField
+                    control={annotationForm.control}
+                    name="species"
+                    render={({ field, fieldState }) => (
+                      <FormItem>
+                        <FormLabel
+                          htmlFor={toDomId(field.name)}
+                          className="m-0"
+                        >
+                          Species
+                        </FormLabel>
+                        <FormControl>
+                          <MorphIdSelectMenu
+                            label="species"
+                            morphIds={Object.values(SPECIES_MORPH_IDS)}
+                            selectedMorphId={field.value}
+                            onMorphSelect={handleSpeciesSelect}
+                            inValid={!!fieldState.error}
+                          />
+                        </FormControl>
+                        <FormMessage className="text-xs" />
+                      </FormItem>
+                    )}
+                  />
 
-                <FormField
-                  control={annotationForm.control}
-                  name="sex"
-                  render={({ field, fieldState }) => (
-                    <FormItem>
-                      <FormLabel htmlFor={toDomId(field.name)} className="m-0">Sex</FormLabel>
-                      <FormControl>
-                        <MorphIdSelectMenu
-                          label="Sex"
-                          morphIds={Object.values(SEX_MORPH_IDS)}
-                          selectedMorphId={field.value}
-                          onMorphSelect={handleSexSelect}
-                          inValid={!!fieldState.error && sexEnabled}
-                          disabled={!sexEnabled}
-                        />
-                      </FormControl>
-                      <FormMessage className="text-xs" />
-                    </FormItem>
-                  )}
-                />
+                  <FormField
+                    control={annotationForm.control}
+                    name="sex"
+                    render={({ field, fieldState }) => (
+                      <FormItem>
+                        <FormLabel
+                          htmlFor={toDomId(field.name)}
+                          className="m-0"
+                        >
+                          Sex
+                        </FormLabel>
+                        <FormControl>
+                          <MorphIdSelectMenu
+                            label="Sex"
+                            morphIds={Object.values(SEX_MORPH_IDS)}
+                            selectedMorphId={field.value}
+                            onMorphSelect={handleSexSelect}
+                            inValid={!!fieldState.error && sexEnabled}
+                            disabled={!sexEnabled}
+                          />
+                        </FormControl>
+                        <FormMessage className="text-xs" />
+                      </FormItem>
+                    )}
+                  />
 
-                <FormField
-                  control={annotationForm.control}
-                  name="abdomenStatus"
-                  render={({ field, fieldState }) => (
-                    <FormItem>
-                      <FormLabel htmlFor={toDomId(field.name)} className="m-0">Abdomen Status</FormLabel>
-                      <FormControl>
-                        <MorphIdSelectMenu
-                          label="Abdomen Status"
-                          morphIds={Object.values(ABDOMEN_STATUS_MORPH_IDS)}
-                          selectedMorphId={field.value}
-                          onMorphSelect={handleAbdomenStatusSelect}
-                          inValid={!!fieldState.error && abdomenStatusEnabled}
-                          disabled={!abdomenStatusEnabled}
-                        />
-                      </FormControl>
-                      <FormMessage className="text-xs" />
-                    </FormItem>
-                  )}
-                />
+                  <FormField
+                    control={annotationForm.control}
+                    name="abdomenStatus"
+                    render={({ field, fieldState }) => (
+                      <FormItem>
+                        <FormLabel
+                          htmlFor={toDomId(field.name)}
+                          className="m-0"
+                        >
+                          Abdomen Status
+                        </FormLabel>
+                        <FormControl>
+                          <MorphIdSelectMenu
+                            label="Abdomen Status"
+                            morphIds={Object.values(ABDOMEN_STATUS_MORPH_IDS)}
+                            selectedMorphId={field.value}
+                            onMorphSelect={handleAbdomenStatusSelect}
+                            inValid={!!fieldState.error && abdomenStatusEnabled}
+                            disabled={!abdomenStatusEnabled}
+                          />
+                        </FormControl>
+                        <FormMessage className="text-xs" />
+                      </FormItem>
+                    )}
+                  />
 
+                  <FormField
+                    control={annotationForm.control}
+                    name="notes"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel
+                          htmlFor={toDomId(field.name)}
+                          className="m-0"
+                        >
+                          Notes
+                          {isFlagged && (
+                            <span className="text-destructive">
+                              (Required)*
+                            </span>
+                          )}
+                        </FormLabel>
+                        <FormControl>
+                          <Textarea
+                            id={toDomId(field.name)}
+                            className="h-[70px] resize-none overflow-y-auto text-sm"
+                            placeholder="Add observations..."
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <div className="flex gap-3 pt-2">
                     <FormField
                       control={annotationForm.control}
-                      name="notes"
+                      name="flagged"
                       render={({ field }) => (
-                        <FormItem>
-                          <FormLabel htmlFor={toDomId(field.name)} className="m-0">
-                            Notes
-                            {isFlagged && (
-                              <span className="text-destructive">(Required)*</span>
+                        <Toggle
+                          pressed={field.value}
+                          onPressedChange={newFlagged =>
+                            handleFlagged(newFlagged, field.onChange)
+                          }
+                          variant="outline"
+                          disabled={annotationForm.formState.isSubmitting}
+                          className={cn(
+                            'flex-1',
+                            'flex items-center justify-center gap-1.5 rounded-md border transition-colors',
+                            'data-[state=on]:bg-destructive/10 data-[state=on]:text-destructive data-[state=on]:border-destructive data-[state=on]:hover:bg-destructive/20 motion-safe:data-[state=on]:animate-pulse',
+                            'data-[state=off]:bg-background data-[state=off]:border-input data-[state=off]:hover:bg-accent data-[state=off]:hover:text-accent-foreground',
+                          )}
+                        >
+                          <Flag
+                            className={cn(
+                              'h-4 w-4',
+                              field.value
+                                ? 'text-destructive'
+                                : 'text-muted-foreground',
                             )}
-                            </FormLabel>
-                          <FormControl>
-                            <Textarea
-                              id={toDomId(field.name)}
-                              className="h-[70px] resize-none text-sm overflow-y-auto"
-                              placeholder="Add observations..."
-                              {...field}
-                              />
-                          </FormControl>
-                          <FormMessage/>
-                        </FormItem>
+                          />
+                          {field.value ? 'Specimen Flagged' : 'Flag Specimen'}
+                        </Toggle>
                       )}
                     />
 
-                    <div className="flex gap-3 pt-2">
-                      <FormField
-                        control={annotationForm.control}
-                        name="flagged"
-                        render={({ field }) => (
-                          <Toggle
-                            pressed={field.value}
-                            onPressedChange={(newFlagged) => handleFlagged(newFlagged, field.onChange)}
-                            variant="outline"
-                            disabled={annotationForm.formState.isSubmitting}
-                            className={cn(
-                              "flex-1", 
-                              "flex items-center justify-center gap-1.5 rounded-md border transition-colors",
-                              "data-[state=on]:bg-destructive/10 data-[state=on]:text-destructive data-[state=on]:border-destructive data-[state=on]:hover:bg-destructive/20 motion-safe:data-[state=on]:animate-pulse",
-                              "data-[state=off]:bg-background data-[state=off]:border-input data-[state=off]:hover:bg-accent data-[state=off]:hover:text-accent-foreground"
-                            )}
-                          >
-                            <Flag className={cn(
-                              "h-4 w-4", 
-                              field.value ? "text-destructive" : "text-muted-foreground"
-                            )} />
-                            {field.value ? 'Specimen Flagged' : 'Flag Specimen'}
-                          </Toggle>
-                        )}
-                          
-                      />
-                      
+                    <Button
+                      type="submit"
+                      className="flex flex-1 items-center justify-center gap-1.5"
+                      disabled={annotationForm.formState.isSubmitting}
+                    >
+                      <Save className="h-4 w-4" />
+                      {annotationForm.formState.isSubmitting
+                        ? 'Submitting...'
+                        : 'Submit'}
+                    </Button>
+                  </div>
 
-                      <Button
-                        type="submit"
-                        className="flex-1 flex items-center justify-center gap-1.5" 
-                        disabled={annotationForm.formState.isSubmitting}
-                      >
-                        <Save className="h-4 w-4" /> 
-                        {annotationForm.formState.isSubmitting ? 'Submitting...' : 'Submit'}
-                      </Button>
-                    </div>
-
-                <CardFooter className="mt-auto flex flex-wrap items-center justify-between gap-3 px-6 py-4">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    className="min-w-[120px]"
-                    onClick={handlePrevious}
-                    disabled={page === 1 || isFetching || isLoading}
-                  >
-                    <ArrowLeft className="mr-2 h-4 w-4" /> Previous
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    className="min-w-[120px]"
-                    onClick={handleNext}
-                    disabled={!hasMore || isFetching || isLoading}
-                  >
-                    Next <ArrowRight className="ml-2 h-4 w-4" />
-                  </Button>
-                </CardFooter>
-              </fieldset>
-            </form>
-          </Form>
-        </CardContent>
-        
-      </div>
-        
+                  <CardFooter className="mt-auto flex flex-wrap items-center justify-between gap-3 px-6 py-4">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="min-w-[120px]"
+                      onClick={handlePrevious}
+                      disabled={page === 1 || isFetching || isLoading}
+                    >
+                      <ArrowLeft className="mr-2 h-4 w-4" /> Previous
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="min-w-[120px]"
+                      onClick={handleNext}
+                      disabled={!hasMore || isFetching || isLoading}
+                    >
+                      Next <ArrowRight className="ml-2 h-4 w-4" />
+                    </Button>
+                  </CardFooter>
+                </fieldset>
+              </form>
+            </Form>
+          </CardContent>
+        </div>
       </Card>
     </div>
   );

--- a/src/lib/annotate/client/hooks/use-update-annotation.ts
+++ b/src/lib/annotate/client/hooks/use-update-annotation.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import { updateAnnotation } from '../update-annotation';
+import type {
+  AnnotationUpdateRequestDto,
+  AnnotationUpdateResponseDto,
+} from '@/lib/entities/annotation';
+
+export function useUpdateAnnotationMutation(
+  options?: Omit<
+    UseMutationOptions<
+      AnnotationUpdateResponseDto,
+      Error,
+      { annotationId: number; payload: AnnotationUpdateRequestDto },
+      unknown
+    >,
+    'mutationFn'
+  >,
+) {
+  return useMutation<
+    AnnotationUpdateResponseDto,
+    Error,
+    { annotationId: number; payload: AnnotationUpdateRequestDto }
+  >({
+    mutationFn: ({ annotationId, payload }) =>
+      updateAnnotation(annotationId, payload),
+    ...(options ?? {}),
+  });
+}

--- a/src/lib/annotate/client/index.ts
+++ b/src/lib/annotate/client/index.ts
@@ -4,4 +4,6 @@ export * from './get-annotation-task-progress';
 export * from './hooks/use-annotation-task-progress';
 export * from './get-annotations';
 export * from './hooks/use-annotations';
+export * from './update-annotation';
+export * from './hooks/use-update-annotation';
 export * from '../types';

--- a/src/lib/annotate/client/update-annotation.ts
+++ b/src/lib/annotate/client/update-annotation.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import bff from '@/lib/shared/http/client/bff-client';
+import type {
+  AnnotationUpdateRequestDto,
+  AnnotationUpdateResponseDto,
+} from '@/lib/entities/annotation';
+import { createJsonRequestInit } from '@/lib/shared/http/core/json';
+
+export async function updateAnnotation(
+  annotationId: number,
+  payload: AnnotationUpdateRequestDto,
+): Promise<AnnotationUpdateResponseDto> {
+  return await bff<AnnotationUpdateResponseDto>(
+    `/annotations/${annotationId}`,
+    {
+      method: 'PUT',
+      ...createJsonRequestInit(payload),
+    },
+  );
+}

--- a/src/lib/entities/annotation/dto.ts
+++ b/src/lib/entities/annotation/dto.ts
@@ -54,3 +54,16 @@ export interface AnnotationTasksListResponseDto {
   offset: number;
   hasMore: boolean;
 }
+
+export interface AnnotationUpdateRequestDto {
+  morphSpecies?: string | null;
+  morphSex?: string | null;
+  morphAbdomenStatus?: string | null;
+  notes?: string | null;
+  status: AnnotationStatus;
+}
+
+export interface AnnotationUpdateResponseDto {
+  message: string;
+  annotation: AnnotationDto;
+}

--- a/src/lib/shared/ui/show-success-toast.ts
+++ b/src/lib/shared/ui/show-success-toast.ts
@@ -1,0 +1,7 @@
+import { toast } from 'sonner';
+
+export function showSuccessToast(
+  message: string = 'Operation completed successfully.',
+) {
+  toast.success(message);
+}


### PR DESCRIPTION
This pull request refactors the annotation form logic for the specimen annotation workflow, moving form state management and validation into a dedicated `AnnotationForm` component. It also improves validation, UI consistency, and code organization for the annotation process. The most important changes are grouped below.

### Annotation Form Refactor and Encapsulation

* Extracted the annotation form logic from `page-client.tsx` into a new, dedicated `AnnotationForm` component (`annotation-form.tsx`). This centralizes all form state management, validation, and submission logic, reducing duplication and simplifying the main page component. [[1]](diffhunk://#diff-c1f4a7074ab62f555042ae6a6b29b3d54d18051079daa2d256ece9669318f1c0R1-R285) [[2]](diffhunk://#diff-80b7d2dc7d8338c83daa13f87a5a03cbf26335438bf0bec78dfc0c97d9066275L13-L116)

### Validation Improvements

* Updated the validation schema in `annotation-form-schema.ts` to use string types for morph IDs and improved custom validation logic to ensure only valid morph IDs are accepted for species, sex, and abdomen status. Also, cleaned up the schema for better readability and maintainability. [[1]](diffhunk://#diff-d264bc065e7b9a184f236a42be2ba03990e9fac65b173be639c3c0a562fadb26L6-R22) [[2]](diffhunk://#diff-d264bc065e7b9a184f236a42be2ba03990e9fac65b173be639c3c0a562fadb26L29-R77)

### UI and Interaction Enhancements

* Improved the `MorphIdSelectMenu` component for better accessibility and UI consistency, including handling of the "clear" selection and visual feedback for invalid fields. [[1]](diffhunk://#diff-5f0f09ca0de5e9b63ac3d62f2a2d8a4e63727fdf0d7c526ea85d9a954990aa82L1-L5) [[2]](diffhunk://#diff-5f0f09ca0de5e9b63ac3d62f2a2d8a4e63727fdf0d7c526ea85d9a954990aa82R29-L79)
* Updated the form to provide clear feedback and disable controls during submission, and added a success toast notification upon successful annotation.

### Code Cleanup

* Removed unused imports and redundant code from `page-client.tsx` and `task-progress-breakdown.tsx`, resulting in a cleaner, more maintainable codebase. [[1]](diffhunk://#diff-80b7d2dc7d8338c83daa13f87a5a03cbf26335438bf0bec78dfc0c97d9066275L13-L116) [[2]](diffhunk://#diff-91138307b5d989cc38074b62b7fb60de3f9ac13de341fff1081f75e4d21f76feL6-L14) [[3]](diffhunk://#diff-91138307b5d989cc38074b62b7fb60de3f9ac13de341fff1081f75e4d21f76feL25) [[4]](diffhunk://#diff-91138307b5d989cc38074b62b7fb60de3f9ac13de341fff1081f75e4d21f76feL79)