### PR TITLE
VCV-28: Dashboard Permission Fix: Enables Review Access for Privilege 1 Users

### DIFF
--- a/src/components/dashboard/dashboard-page-client.tsx
+++ b/src/components/dashboard/dashboard-page-client.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { useUserPermissionsQuery } from '@/lib/user/client';
-import { canViewAndWriteAnnotationTasks } from '@/lib/user/permissions';
+import {
+  canViewAndWriteAnnotationTasks,
+  canViewSites,
+} from '@/lib/user/permissions';
 import { Button } from '../ui/button';
 import {
   Card,
@@ -27,87 +30,93 @@ export function DashboardPageClient() {
     router.push('/review');
   };
 
-  return (
-    <Fragment>
-      {permissions && canViewAndWriteAnnotationTasks(permissions) && (
-        <div className="mx-auto w-full max-w-2xl px-6 py-10">
-          <div className="space-y-6">
-            {/* Annotation Card */}
-            <Card className="rounded-2xl border shadow-sm">
-              <CardHeader className="space-y-3">
-                <div className="bg-primary/10 text-primary ring-primary/20 inline-flex h-10 w-10 items-center justify-center rounded-full ring-1">
-                  <PencilLine className="h-5 w-5" />
-                </div>
-                <CardTitle className="tracking-tight">
-                  Start annotating
-                </CardTitle>
-                <CardDescription>
-                  Review and label your assigned tasks.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="text-muted-foreground text-sm">
-                Access your queue and continue where you left off.
-              </CardContent>
-              <CardFooter className="flex items-end justify-end">
-                <Button
-                  onClick={handleAnnotateClick}
-                  disabled={isLoading}
-                  size="sm"
-                  aria-busy={isLoading}
-                >
-                  {isLoading ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Preparing...
-                    </>
-                  ) : (
-                    <>
-                      Annotate
-                      <ArrowRight className="ml-2 h-4 w-4" />
-                    </>
-                  )}
-                </Button>
-              </CardFooter>
-            </Card>
+  const canAnnotate =
+    permissions && canViewAndWriteAnnotationTasks(permissions);
+  const canReview = permissions && canViewSites(permissions);
+  const hasAnyAccess = canAnnotate || canReview;
 
-            {/* Review Data Card */}
-            <Card className="rounded-2xl border shadow-sm">
-              <CardHeader className="space-y-3">
-                <div className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-blue-500/10 text-blue-600 ring-1 ring-blue-500/20">
-                  <Search className="h-5 w-5" />
-                </div>
-                <CardTitle className="tracking-tight">Review Data</CardTitle>
-                <CardDescription>
-                  Review and validate completed surveillance.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="text-muted-foreground text-sm">
-                Browse and verify surveillance documentation quality and
-                accuracy.
-              </CardContent>
-              <CardFooter className="flex items-end justify-end">
-                <Button
-                  onClick={handleReviewClick}
-                  disabled={isLoading}
-                  size="sm"
-                >
-                  {isLoading ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Loading...
-                    </>
-                  ) : (
-                    <>
-                      Review Data
-                      <ArrowRight className="ml-2 h-4 w-4" />
-                    </>
-                  )}
-                </Button>
-              </CardFooter>
-            </Card>
-          </div>
-        </div>
-      )}
-    </Fragment>
+  if (!hasAnyAccess) {
+    return null;
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-6 py-10">
+      <div className="space-y-6">
+        {/* Annotation Card - Only show if user can annotate */}
+        {canAnnotate && (
+          <Card className="rounded-2xl border shadow-sm">
+            <CardHeader className="space-y-3">
+              <div className="bg-primary/10 text-primary ring-primary/20 inline-flex h-10 w-10 items-center justify-center rounded-full ring-1">
+                <PencilLine className="h-5 w-5" />
+              </div>
+              <CardTitle className="tracking-tight">Start annotating</CardTitle>
+              <CardDescription>
+                Review and label your assigned tasks.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="text-muted-foreground text-sm">
+              Access your queue and continue where you left off.
+            </CardContent>
+            <CardFooter className="flex items-end justify-end">
+              <Button
+                onClick={handleAnnotateClick}
+                disabled={isLoading}
+                size="sm"
+                aria-busy={isLoading}
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Preparing...
+                  </>
+                ) : (
+                  <>
+                    Annotate
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </>
+                )}
+              </Button>
+            </CardFooter>
+          </Card>
+        )}
+
+        {/* Review Data Card - Show if user can view sites (privilege 0, 1, 2) */}
+        {canReview && (
+          <Card className="rounded-2xl border shadow-sm">
+            <CardHeader className="space-y-3">
+              <div className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-blue-500/10 text-blue-600 ring-1 ring-blue-500/20">
+                <Search className="h-5 w-5" />
+              </div>
+              <CardTitle className="tracking-tight">Review Data</CardTitle>
+              <CardDescription>
+                Review and validate completed surveillance.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="text-muted-foreground text-sm">
+              Browse and verify surveillance documentation quality and accuracy.
+            </CardContent>
+            <CardFooter className="flex items-end justify-end">
+              <Button
+                onClick={handleReviewClick}
+                disabled={isLoading}
+                size="sm"
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Loading...
+                  </>
+                ) : (
+                  <>
+                    Review Data
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </>
+                )}
+              </Button>
+            </CardFooter>
+          </Card>
+        )}
+      </div>
+    </div>
   );
 }

--- a/src/components/dashboard/dashboard-page-client.tsx
+++ b/src/components/dashboard/dashboard-page-client.tsx
@@ -36,7 +36,22 @@ export function DashboardPageClient() {
   const hasAnyAccess = canAnnotate || canReview;
 
   if (!hasAnyAccess) {
-    return null;
+    return (
+      <div className="mx-auto w-full max-w-2xl px-6 py-10">
+        <div className="flex flex-col items-center justify-center space-y-4 text-center">
+          <div className="bg-muted inline-flex h-12 w-12 items-center justify-center rounded-full">
+            <Search className="text-muted-foreground h-6 w-6" />
+          </div>
+          <div className="space-y-2">
+            <h2 className="text-lg font-semibold">No Access Available</h2>
+            <p className="text-muted-foreground max-w-md text-sm">
+              You don't currently have access to any features. Please contact
+              your administrator if you believe this is an error.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
- Fixed blank dashboard issue - Separated annotation and review card permission checks so privilege 1 users can access review functionality
- Maintained security boundaries - Annotation card remains restricted to privilege 2 users while review card is accessible to all users with site viewing permissions
- Preserved code architecture - Solution follows existing patterns with proper separation of concerns, single responsibility principle, and clean file structure

✅ Privilege 0: Can access review (read-only for single district) - canViewSites() returns true for permissions.sites.viewSiteMetadata
✅ Privilege 1: Can access review (read/write/push for single district) - canViewSites() returns true for permissions.sites.viewSiteMetadata
✅ Privilege 2: Can access review (full access across districts) - canViewSites() returns true for permissions.sites.viewSiteMetadata