### PR TITLE
VCV-104: Default review entry to Master Table View

### DIFF
--- a/src/features/dashboard/components/back-button.tsx
+++ b/src/features/dashboard/components/back-button.tsx
@@ -137,33 +137,6 @@ export function BackButton({ show, district, monthYear }: BackButtonProps) {
                         className={cn(
                           'h-10 w-full justify-start gap-3 pl-8',
                           isActivePath(
-                            `/review/${district}/${monthYear}/dashboard`,
-                          ) &&
-                            'bg-green-50 text-green-700 hover:bg-green-100 hover:text-green-700',
-                        )}
-                        onClick={() =>
-                          handleNavigate(
-                            `/review/${district}/${monthYear}/dashboard`,
-                          )
-                        }
-                      >
-                        <LayoutDashboard
-                          className={cn(
-                            'h-4 w-4',
-                            isActivePath(
-                              `/review/${district}/${monthYear}/dashboard`,
-                            ) && 'text-green-600',
-                          )}
-                        />
-                        <span>Dashboard</span>
-                      </Button>
-
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        className={cn(
-                          'h-10 w-full justify-start gap-3 pl-8',
-                          isActivePath(
                             `/review/${district}/${monthYear}/master-table-view`,
                           ) &&
                             'bg-green-50 text-green-700 hover:bg-green-100 hover:text-green-700',
@@ -183,6 +156,33 @@ export function BackButton({ show, district, monthYear }: BackButtonProps) {
                           )}
                         />
                         <span>Master Table View</span>
+                      </Button>
+
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        className={cn(
+                          'h-10 w-full justify-start gap-3 pl-8',
+                          isActivePath(
+                            `/review/${district}/${monthYear}/dashboard`,
+                          ) &&
+                            'bg-green-50 text-green-700 hover:bg-green-100 hover:text-green-700',
+                        )}
+                        onClick={() =>
+                          handleNavigate(
+                            `/review/${district}/${monthYear}/dashboard`,
+                          )
+                        }
+                      >
+                        <LayoutDashboard
+                          className={cn(
+                            'h-4 w-4',
+                            isActivePath(
+                              `/review/${district}/${monthYear}/dashboard`,
+                            ) && 'text-green-600',
+                          )}
+                        />
+                        <span>Metrics Dashboard</span>
                       </Button>
 
                       <Button

--- a/src/features/review/components/data-list/columns.tsx
+++ b/src/features/review/components/data-list/columns.tsx
@@ -1,6 +1,6 @@
 import { ColumnDef } from '@tanstack/react-table';
 import { Button } from '@/ui/button';
-import { BarChart3 } from 'lucide-react';
+import { Table } from 'lucide-react';
 import type { MonthlySummary } from '@/features/review/types';
 
 interface CreateColumnsParams {
@@ -60,8 +60,8 @@ export function createMonthlySummaryColumns({
               }
               className="h-auto p-0 font-normal text-blue-600 hover:text-blue-800"
             >
-              <BarChart3 className="mr-1 h-3 w-3" />
-              Dashboard
+              <Table className="mr-1 h-3 w-3" />
+              View Table
             </Button>
           </div>
         );

--- a/src/features/review/components/data-list/page-client.tsx
+++ b/src/features/review/components/data-list/page-client.tsx
@@ -12,7 +12,7 @@ import { createMonthlySummaryColumns } from './columns';
 import { useMonthlySummaryQuery } from '@/features/review/hooks/use-monthly-summary';
 import { useTablePagination } from '@/shared/core/hooks/use-table-pagination';
 import { useDistrictManagement } from '@/features/review/hooks/use-district-management';
-import { buildDashboardPath } from '@/features/review/utils/navigation';
+import { buildMasterTableViewPath } from '@/features/review/utils/navigation';
 import { PAGE_SIZES } from '@/shared/entities/pagination';
 
 export function ReviewDataListPageClient() {
@@ -82,7 +82,7 @@ export function ReviewDataListPageClient() {
 
   const handleNavigateToDashboard = useCallback(
     (district: string, monthYear: string) => {
-      router.push(buildDashboardPath(district, monthYear));
+      router.push(buildMasterTableViewPath(district, monthYear));
     },
     [router],
   );

--- a/src/features/review/utils/navigation.ts
+++ b/src/features/review/utils/navigation.ts
@@ -10,3 +10,10 @@ export function buildDashboardPath(
 ): string {
   return `${buildReviewPath(district, monthYear)}/dashboard`;
 }
+
+export function buildMasterTableViewPath(
+  district: string,
+  monthYear: string,
+): string {
+  return `${buildReviewPath(district, monthYear)}/master-table-view`;
+}

--- a/src/features/review/utils/navigation.ts
+++ b/src/features/review/utils/navigation.ts
@@ -4,13 +4,6 @@ export function buildReviewPath(district: string, monthYear: string): string {
   return `/review/${encodedDistrict}/${encodedMonthYear}`;
 }
 
-export function buildDashboardPath(
-  district: string,
-  monthYear: string,
-): string {
-  return `${buildReviewPath(district, monthYear)}/dashboard`;
-}
-
 export function buildMasterTableViewPath(
   district: string,
   monthYear: string,


### PR DESCRIPTION
- Review data list: row action goes to Master Table View (was metrics dashboard)
- Add buildMasterTableViewPath; list uses it for navigation
- Sidebar: Master Table View first, then Metrics Dashboard
- List button: label "View Table", Table icon (was "Dashboard", BarChart3)
- Sidebar: label "Metrics Dashboard" (was "Dashboard")