### PR TITLE
VCV-92: Edit model predictions for specimens in specimen view

### DIFF
--- a/src/features/review/api/update-specimen.ts
+++ b/src/features/review/api/update-specimen.ts
@@ -2,21 +2,21 @@
 
 import bff from '@/shared/infra/api/bff-client';
 import {
-    SpecimenUpdateRequestDto,
-    SpecimenUpdateResponseDto
+  SpecimenUpdateRequestDto,
+  SpecimenUpdateResponseDto,
 } from '@/features/review/types';
 import { createJsonRequestInit } from '@/shared/infra/http/core/json';
 
 export async function updateSpecimen(
-    specimenId: number,
-    thumbnailImageId: number,
-    payload: SpecimenUpdateRequestDto,
+  specimenId: number,
+  thumbnailImageId: number,
+  payload: SpecimenUpdateRequestDto,
 ): Promise<SpecimenUpdateResponseDto> {
-    return await bff<SpecimenUpdateResponseDto>(
-        `/specimens/${specimenId}/images/data/${thumbnailImageId}`,
-        {
-            method: 'PUT',
-            ...createJsonRequestInit(payload),
-        }
-    );
+  return await bff<SpecimenUpdateResponseDto>(
+    `/specimens/${specimenId}/images/data/${thumbnailImageId}`,
+    {
+      method: 'PUT',
+      ...createJsonRequestInit(payload),
+    },
+  );
 }

--- a/src/features/review/api/update-specimen.ts
+++ b/src/features/review/api/update-specimen.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import bff from '@/shared/infra/api/bff-client';
+import {
+    SpecimenUpdateRequestDto,
+    SpecimenUpdateResponseDto
+} from '@/features/review/types';
+import { createJsonRequestInit } from '@/shared/infra/http/core/json';
+
+export async function updateSpecimen(
+    specimenId: number,
+    thumbnailImageId: number,
+    payload: SpecimenUpdateRequestDto,
+): Promise<SpecimenUpdateResponseDto> {
+    return await bff<SpecimenUpdateResponseDto>(
+        `/specimens/${specimenId}/images/data/${thumbnailImageId}`,
+        {
+            method: 'PUT',
+            ...createJsonRequestInit(payload),
+        }
+    );
+}

--- a/src/features/review/components/specimen-view/image-modal/image-modal-header.tsx
+++ b/src/features/review/components/specimen-view/image-modal/image-modal-header.tsx
@@ -18,7 +18,7 @@ import {
   SEX_MORPH_IDS,
   ABDOMEN_STATUS_MORPH_IDS,
 } from '@/shared/entities/specimen/morph-ids';
-import { useUpdateSpecimennMutation } from '@/features/review/hooks/use-update-specimen';
+import { useUpdateSpecimenMutation } from '@/features/review/hooks/use-update-specimen';
 import {
   isSpeciesEnabled,
   isSexEnabled,
@@ -70,7 +70,7 @@ export function ImageModalHeader({
     null,
   );
 
-  const updateMutation = useUpdateSpecimennMutation({
+  const updateMutation = useUpdateSpecimenMutation({
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: reviewKeys.specimenImages(specimenId),

--- a/src/features/review/components/specimen-view/image-modal/image-modal-header.tsx
+++ b/src/features/review/components/specimen-view/image-modal/image-modal-header.tsx
@@ -165,7 +165,6 @@ export function ImageModalHeader({
               <SelectValue placeholder="Select Species" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="none">None</SelectItem>
               {SPECIES_OPTIONS.map(opt => (
                 <SelectItem key={opt} value={opt}>
                   {opt}
@@ -183,7 +182,7 @@ export function ImageModalHeader({
               <SelectValue placeholder="Select Sex" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="none">None</SelectItem>
+              {!sexEnabled && <SelectItem value="none">None</SelectItem>}
               {SEX_OPTIONS.map(opt => (
                 <SelectItem key={opt} value={opt}>
                   {opt}
@@ -201,7 +200,7 @@ export function ImageModalHeader({
               <SelectValue placeholder="Abdomen Status" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="none">None</SelectItem>
+              {!abdomenStatusEnabled && <SelectItem value="none">None</SelectItem>}
               {ABDOMEN_STATUS_OPTIONS.map(opt => (
                 <SelectItem key={opt} value={opt}>
                   {opt}

--- a/src/features/review/components/specimen-view/image-modal/image-modal-header.tsx
+++ b/src/features/review/components/specimen-view/image-modal/image-modal-header.tsx
@@ -66,11 +66,15 @@ export function ImageModalHeader({
   const [isEditing, setIsEditing] = useState(false);
   const [editSpecies, setEditSpecies] = useState<string | null>(null);
   const [editSex, setEditSex] = useState<string | null>(null);
-  const [editAbdomenStatus, setEditAbdomenStatus] = useState<string | null>(null);
+  const [editAbdomenStatus, setEditAbdomenStatus] = useState<string | null>(
+    null,
+  );
 
   const updateMutation = useUpdateSpecimennMutation({
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: reviewKeys.specimenImages(specimenId) });
+      queryClient.invalidateQueries({
+        queryKey: reviewKeys.specimenImages(specimenId),
+      });
       showSuccessToast('Specimen updated successfully.');
       setIsEditing(false);
     },
@@ -84,7 +88,10 @@ export function ImageModalHeader({
   const currentSex = isEditing ? editSex : sex;
 
   const sexEnabled = isSexEnabled(currentGenus);
-  const abdomenStatusEnabled = isAbdomenStatusEnabled(currentGenus, currentSex ?? undefined);
+  const abdomenStatusEnabled = isAbdomenStatusEnabled(
+    currentGenus,
+    currentSex ?? undefined,
+  );
 
   function handleEditClick() {
     setEditSpecies(species ?? null);
@@ -103,9 +110,9 @@ export function ImageModalHeader({
   function handleSpeciesChange(value: string) {
     const newSpecies = value === 'none' ? null : value;
     setEditSpecies(newSpecies);
-    
+
     const newGenus = parseGenus(newSpecies);
-    
+
     if (!isSexEnabled(newGenus)) {
       setEditSex(null);
       setEditAbdomenStatus(null);
@@ -115,7 +122,7 @@ export function ImageModalHeader({
   function handleSexChange(value: string) {
     const newSex = value === 'none' ? null : value;
     setEditSex(newSex);
-    
+
     if (!isAbdomenStatusEnabled(currentGenus, newSex ?? undefined)) {
       setEditAbdomenStatus(null);
     }
@@ -200,7 +207,9 @@ export function ImageModalHeader({
               <SelectValue placeholder="Abdomen Status" />
             </SelectTrigger>
             <SelectContent>
-              {!abdomenStatusEnabled && <SelectItem value="none">None</SelectItem>}
+              {!abdomenStatusEnabled && (
+                <SelectItem value="none">None</SelectItem>
+              )}
               {ABDOMEN_STATUS_OPTIONS.map(opt => (
                 <SelectItem key={opt} value={opt}>
                   {opt}
@@ -239,7 +248,9 @@ export function ImageModalHeader({
             {sex && <div>Sex: {sex}</div>}
             {abdomenStatus && <div>Abdomen Status: {abdomenStatus}</div>}
             {!species && !sex && !abdomenStatus && (
-              <div className="text-muted-foreground/60 italic">No classification data</div>
+              <div className="text-muted-foreground/60 italic">
+                No classification data
+              </div>
             )}
           </div>
           <Button

--- a/src/features/review/components/specimen-view/image-modal/image-modal-header.tsx
+++ b/src/features/review/components/specimen-view/image-modal/image-modal-header.tsx
@@ -1,12 +1,57 @@
 'use client';
 
+import { useState } from 'react';
 import { DialogTitle } from '@/ui/dialog';
 import { Button } from '@/ui/button';
-import { X } from 'lucide-react';
+import { X, Pencil, Check, XIcon } from 'lucide-react';
 import type { SpecimenImage } from '@/shared/entities/specimen-image/model';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/ui/select';
+import {
+  GENUS_MORPH_IDS,
+  SPECIES_MORPH_IDS,
+  SEX_MORPH_IDS,
+  ABDOMEN_STATUS_MORPH_IDS,
+} from '@/shared/entities/specimen/morph-ids';
+import { useUpdateSpecimennMutation } from '@/features/review/hooks/use-update-specimen';
+import {
+  isSpeciesEnabled,
+  isSexEnabled,
+  isAbdomenStatusEnabled,
+} from '@/features/annotation/components/task-detail/annotation-form-panel/validation/annotation-form-schema';
+import { useQueryClient } from '@tanstack/react-query';
+import { showSuccessToast } from '@/ui/show-success-toast';
+import { reviewKeys } from '@/features/review/api/review-keys';
+
+const SPECIES_OPTIONS = [
+  ...Object.values(SPECIES_MORPH_IDS).map(
+    species => `${GENUS_MORPH_IDS.ANOPHELES}${species}`,
+  ),
+  GENUS_MORPH_IDS.CULEX,
+  GENUS_MORPH_IDS.AEDES,
+  GENUS_MORPH_IDS.MANSIONIA,
+  GENUS_MORPH_IDS.NON_MOSQUITO,
+];
+
+const SEX_OPTIONS = Object.values(SEX_MORPH_IDS);
+const ABDOMEN_STATUS_OPTIONS = Object.values(ABDOMEN_STATUS_MORPH_IDS);
+
+function parseGenus(species: string | null | undefined): string | undefined {
+  if (!species) return undefined;
+  if (species.startsWith(GENUS_MORPH_IDS.ANOPHELES)) {
+    return GENUS_MORPH_IDS.ANOPHELES;
+  }
+  return species;
+}
 
 interface ImageModalHeaderProps {
-  specimenId: string;
+  specimenId: number;
+  thumbnailImageId: number;
   thumbnailImage: SpecimenImage | null | undefined;
   onClose: () => void;
 }
@@ -14,11 +59,83 @@ interface ImageModalHeaderProps {
 export function ImageModalHeader({
   specimenId,
   thumbnailImage,
+  thumbnailImageId,
   onClose,
 }: ImageModalHeaderProps) {
+  const queryClient = useQueryClient();
+  const [isEditing, setIsEditing] = useState(false);
+  const [editSpecies, setEditSpecies] = useState<string | null>(null);
+  const [editSex, setEditSex] = useState<string | null>(null);
+  const [editAbdomenStatus, setEditAbdomenStatus] = useState<string | null>(null);
+
+  const updateMutation = useUpdateSpecimennMutation({
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: reviewKeys.specimenImages(specimenId) });
+      showSuccessToast('Specimen updated successfully.');
+      setIsEditing(false);
+    },
+  });
+
   const species = thumbnailImage?.species;
   const sex = thumbnailImage?.sex;
   const abdomenStatus = thumbnailImage?.abdomenStatus;
+
+  const currentGenus = parseGenus(isEditing ? editSpecies : species);
+  const currentSex = isEditing ? editSex : sex;
+
+  const sexEnabled = isSexEnabled(currentGenus);
+  const abdomenStatusEnabled = isAbdomenStatusEnabled(currentGenus, currentSex ?? undefined);
+
+  function handleEditClick() {
+    setEditSpecies(species ?? null);
+    setEditSex(sex ?? null);
+    setEditAbdomenStatus(abdomenStatus ?? null);
+    setIsEditing(true);
+  }
+
+  function handleCancelEdit() {
+    setIsEditing(false);
+    setEditSpecies(null);
+    setEditSex(null);
+    setEditAbdomenStatus(null);
+  }
+
+  function handleSpeciesChange(value: string) {
+    const newSpecies = value === 'none' ? null : value;
+    setEditSpecies(newSpecies);
+    
+    const newGenus = parseGenus(newSpecies);
+    
+    if (!isSexEnabled(newGenus)) {
+      setEditSex(null);
+      setEditAbdomenStatus(null);
+    }
+  }
+
+  function handleSexChange(value: string) {
+    const newSex = value === 'none' ? null : value;
+    setEditSex(newSex);
+    
+    if (!isAbdomenStatusEnabled(currentGenus, newSex ?? undefined)) {
+      setEditAbdomenStatus(null);
+    }
+  }
+
+  function handleAbdomenStatusChange(value: string) {
+    setEditAbdomenStatus(value === 'none' ? null : value);
+  }
+
+  async function handleSave() {
+    await updateMutation.mutateAsync({
+      thumbnailImageId,
+      specimenId,
+      payload: {
+        species: editSpecies,
+        sex: editSex,
+        abdomenStatus: editAbdomenStatus,
+      },
+    });
+  }
 
   return (
     <div className="border-b px-4 pt-3 pb-2">
@@ -36,11 +153,105 @@ export function ImageModalHeader({
           <span className="sr-only">Close</span>
         </Button>
       </div>
-      {(species || sex || abdomenStatus) && (
-        <div className="text-muted-foreground flex items-center gap-4 pt-1 text-sm">
-          {species && <div>Species: {species}</div>}
-          {sex && <div>Sex: {sex}</div>}
-          {abdomenStatus && <div>Abdomen Status: {abdomenStatus}</div>}
+
+      {isEditing ? (
+        <div className="flex flex-wrap items-center gap-3 pt-2">
+          <Select
+            value={editSpecies ?? 'none'}
+            onValueChange={handleSpeciesChange}
+            disabled={updateMutation.isPending}
+          >
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Select Species" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="none">None</SelectItem>
+              {SPECIES_OPTIONS.map(opt => (
+                <SelectItem key={opt} value={opt}>
+                  {opt}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Select
+            value={editSex ?? 'none'}
+            onValueChange={handleSexChange}
+            disabled={updateMutation.isPending || !sexEnabled}
+          >
+            <SelectTrigger className="w-28">
+              <SelectValue placeholder="Select Sex" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="none">None</SelectItem>
+              {SEX_OPTIONS.map(opt => (
+                <SelectItem key={opt} value={opt}>
+                  {opt}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Select
+            value={editAbdomenStatus ?? 'none'}
+            onValueChange={handleAbdomenStatusChange}
+            disabled={updateMutation.isPending || !abdomenStatusEnabled}
+          >
+            <SelectTrigger className="w-32">
+              <SelectValue placeholder="Abdomen Status" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="none">None</SelectItem>
+              {ABDOMEN_STATUS_OPTIONS.map(opt => (
+                <SelectItem key={opt} value={opt}>
+                  {opt}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-green-600 hover:bg-green-100 hover:text-green-700"
+              onClick={handleSave}
+              disabled={updateMutation.isPending}
+            >
+              <Check className="h-4 w-4" />
+              <span className="sr-only">Save</span>
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-red-600 hover:bg-red-100 hover:text-red-700"
+              onClick={handleCancelEdit}
+              disabled={updateMutation.isPending}
+            >
+              <XIcon className="h-4 w-4" />
+              <span className="sr-only">Cancel</span>
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center justify-between pt-1">
+          <div className="text-muted-foreground flex items-center gap-4 text-sm">
+            {species && <div>Species: {species}</div>}
+            {sex && <div>Sex: {sex}</div>}
+            {abdomenStatus && <div>Abdomen Status: {abdomenStatus}</div>}
+            {!species && !sex && !abdomenStatus && (
+              <div className="text-muted-foreground/60 italic">No classification data</div>
+            )}
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1.5 text-xs"
+            onClick={handleEditClick}
+          >
+            <Pencil className="h-3.5 w-3.5" />
+            Edit
+          </Button>
         </div>
       )}
     </div>

--- a/src/features/review/components/specimen-view/image-modal/image-modal.tsx
+++ b/src/features/review/components/specimen-view/image-modal/image-modal.tsx
@@ -19,6 +19,13 @@ export function ImageModal({ specimen, onClose }: ImageModalProps) {
   const { data: imagesData, isLoading: isLoadingImages } =
     useSpecimenImagesQuery(specimen.id);
 
+  const thumbnailImage = useMemo(() => {
+    if (imagesData?.images && imagesData.images.length > 0) {
+      return imagesData.images[0];
+    }
+    return specimen.thumbnailImage;
+  }, [imagesData, specimen.thumbnailImage]);
+
   const imageUrl = useMemo(() => {
     if (imagesData?.images && imagesData.images.length > 0) {
       const firstImage = imagesData.images[0];
@@ -43,8 +50,9 @@ export function ImageModal({ specimen, onClose }: ImageModalProps) {
         overlayClassName="bg-white/80"
       >
         <ImageModalHeader
-          specimenId={specimen.specimenId}
-          thumbnailImage={specimen.thumbnailImage}
+          specimenId={specimen.id}
+          thumbnailImage={thumbnailImage}
+          thumbnailImageId={specimen.thumbnailImageId}
           onClose={onClose}
         />
         <ImageModalContent

--- a/src/features/review/components/specimen-view/page-client.tsx
+++ b/src/features/review/components/specimen-view/page-client.tsx
@@ -118,7 +118,7 @@ export function SpecimenViewPageClient({
 
             {districtSites.length > 0 && (
               <div className="flex items-center gap-2">
-                <span className="text-muted-foreground whitespace-nowrap text-sm">
+                <span className="text-muted-foreground text-sm whitespace-nowrap">
                   Per page:
                 </span>
                 <Select

--- a/src/features/review/hooks/use-update-specimen.ts
+++ b/src/features/review/hooks/use-update-specimen.ts
@@ -7,7 +7,7 @@ import type {
   SpecimenUpdateResponseDto,
 } from '@/features/review/types';
 
-export function useUpdateSpecimennMutation(
+export function useUpdateSpecimenMutation(
   options?: Omit<
     UseMutationOptions<
       SpecimenUpdateResponseDto,

--- a/src/features/review/hooks/use-update-specimen.ts
+++ b/src/features/review/hooks/use-update-specimen.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import { updateSpecimen } from '@/features/review/api/update-specimen';
+import type {
+  SpecimenUpdateRequestDto,
+  SpecimenUpdateResponseDto,
+} from '@/features/review/types';
+
+export function useUpdateSpecimennMutation(
+  options?: Omit<
+    UseMutationOptions<
+      SpecimenUpdateResponseDto,
+      Error,
+      { specimenId: number; thumbnailImageId: number; payload: SpecimenUpdateRequestDto },
+      unknown
+    >,
+    'mutationFn'
+  >,
+) {
+  return useMutation<
+    SpecimenUpdateResponseDto,
+    Error,
+    { specimenId: number; thumbnailImageId: number; payload: SpecimenUpdateRequestDto }
+  >({
+    mutationFn: ({ specimenId, thumbnailImageId, payload }) =>
+      updateSpecimen(specimenId, thumbnailImageId, payload),
+    ...(options ?? {}),
+  });
+}

--- a/src/features/review/hooks/use-update-specimen.ts
+++ b/src/features/review/hooks/use-update-specimen.ts
@@ -12,7 +12,11 @@ export function useUpdateSpecimennMutation(
     UseMutationOptions<
       SpecimenUpdateResponseDto,
       Error,
-      { specimenId: number; thumbnailImageId: number; payload: SpecimenUpdateRequestDto },
+      {
+        specimenId: number;
+        thumbnailImageId: number;
+        payload: SpecimenUpdateRequestDto;
+      },
       unknown
     >,
     'mutationFn'
@@ -21,7 +25,11 @@ export function useUpdateSpecimennMutation(
   return useMutation<
     SpecimenUpdateResponseDto,
     Error,
-    { specimenId: number; thumbnailImageId: number; payload: SpecimenUpdateRequestDto }
+    {
+      specimenId: number;
+      thumbnailImageId: number;
+      payload: SpecimenUpdateRequestDto;
+    }
   >({
     mutationFn: ({ specimenId, thumbnailImageId, payload }) =>
       updateSpecimen(specimenId, thumbnailImageId, payload),

--- a/src/features/review/types/request.dto.ts
+++ b/src/features/review/types/request.dto.ts
@@ -76,3 +76,9 @@ export interface DiscrepancyUpdateRequestDto {
   resolvedData?: ResolvedData;
   resolvedSurveillanceForm?: SurveillanceForm;
 }
+
+export interface SpecimenUpdateRequestDto{
+  species?: string | null;
+  sex?: string | null;
+  abdomenStatus?: string | null;
+}

--- a/src/features/review/types/request.dto.ts
+++ b/src/features/review/types/request.dto.ts
@@ -77,7 +77,7 @@ export interface DiscrepancyUpdateRequestDto {
   resolvedSurveillanceForm?: SurveillanceForm;
 }
 
-export interface SpecimenUpdateRequestDto{
+export interface SpecimenUpdateRequestDto {
   species?: string | null;
   sex?: string | null;
   abdomenStatus?: string | null;

--- a/src/features/review/types/response.dto.ts
+++ b/src/features/review/types/response.dto.ts
@@ -1,6 +1,6 @@
 import type { SiteDto } from '@/shared/entities/site/dto';
 import type { SessionDto } from '@/shared/entities/session/dto';
-
+import type { SpecimenImage } from '@/shared/entities/specimen-image';
 export interface ReviewItemDto {
   district: string;
   year: number;
@@ -77,4 +77,9 @@ export interface DiscrepancyUpdateResponseDto {
   message: string;
   resolutionId: number;
   updatedSessionCount: number;
+}
+
+export interface SpecimenUpdateResponseDto{
+  message: string;
+  image: SpecimenImage;
 }

--- a/src/features/review/types/response.dto.ts
+++ b/src/features/review/types/response.dto.ts
@@ -79,7 +79,7 @@ export interface DiscrepancyUpdateResponseDto {
   updatedSessionCount: number;
 }
 
-export interface SpecimenUpdateResponseDto{
+export interface SpecimenUpdateResponseDto {
   message: string;
   image: SpecimenImage;
 }

--- a/src/shared/entities/specimen-image/dto.ts
+++ b/src/shared/entities/specimen-image/dto.ts
@@ -6,6 +6,8 @@ export interface SpecimenImageDto {
   abdomenStatus: string | null;
   capturedAt: number | null;
   submittedAt: number;
+  inferenceResult: string | null;
+  filemd5: string;
 }
 
 export interface SpecimenImagesResponseDto {

--- a/src/shared/entities/specimen-image/model.ts
+++ b/src/shared/entities/specimen-image/model.ts
@@ -6,4 +6,6 @@ export interface SpecimenImage {
   abdomenStatus: string | null;
   capturedAt: number | null;
   submittedAt: number;
+  inferenceResult: string | null;
+  filemd5: string;
 }

--- a/src/shared/entities/specimen/dto.ts
+++ b/src/shared/entities/specimen/dto.ts
@@ -6,7 +6,7 @@ export interface SpecimenDto {
   specimenId: string;
   sessionId: number;
   thumbnailUrl: string | null;
-  thumbnailImageId: number | null;
+  thumbnailImageId: number;
   shouldProcessFurther: boolean;
 }
 

--- a/src/shared/entities/specimen/model.ts
+++ b/src/shared/entities/specimen/model.ts
@@ -6,7 +6,7 @@ export interface Specimen {
   specimenId: string;
   sessionId: number;
   thumbnailUrl: string | null;
-  thumbnailImageId: number | null;
+  thumbnailImageId: number;
   shouldProcessFurther: boolean;
   images?: SpecimenImage[];
   thumbnailImage?: SpecimenImage | null;


### PR DESCRIPTION
- Allows user to edit the specimen's species, sex, and abdomen status as they see fit. 
- Added update-specimen hook and api call, sending in a payload of species, sex, and abdomen status, updating database based on the values the user put in. 