### PR TITLE
VCV-162: replace generic location hierarchy structure

### DIFF
--- a/src/api/site/utils.ts
+++ b/src/api/site/utils.ts
@@ -7,3 +7,25 @@ export function getSiteTopLevelLocation(site: Site): string | undefined {
 export function getSitesLocationLabel(sites: Site[]): string {
     return Object.keys(sites[0]?.locationHierarchy ?? {})[0] ?? 'District';
 }
+
+const LEGACY_HIERARCHY_LEVELS = [
+    { key: 'subCounty', label: 'Subcounty' },
+    { key: 'healthCenter', label: 'Health Center' },
+    { key: 'parish', label: 'Parish' },
+    { key: 'villageName', label: 'Village' },
+    { key: 'houseNumber', label: 'House' },
+];
+
+export function getHierarchyLevels(
+    sites: Site[],
+): { key: string; label: string }[] {
+    const firstSite = sites[0];
+    if (!firstSite) return LEGACY_HIERARCHY_LEVELS;
+
+    const hierarchyKeys = Object.keys(firstSite.locationHierarchy);
+    if (hierarchyKeys.length > 0) {
+        return hierarchyKeys.slice(1).map(key => ({ key, label: key }));
+    }
+
+    return LEGACY_HIERARCHY_LEVELS;
+}

--- a/src/api/site/utils.ts
+++ b/src/api/site/utils.ts
@@ -1,0 +1,9 @@
+import type { Site } from './validation/site-schema';
+
+export function getSiteTopLevelLocation(site: Site): string | undefined {
+    return (Object.values(site.locationHierarchy)[0] ?? site.district)?.trim();
+}
+
+export function getSiteLocationLabel(sites: Site[]): string {
+    return Object.keys(sites[0]?.locationHierarchy ?? {})[0] ?? 'District';
+}

--- a/src/api/site/utils.ts
+++ b/src/api/site/utils.ts
@@ -4,6 +4,6 @@ export function getSiteTopLevelLocation(site: Site): string | undefined {
     return (Object.values(site.locationHierarchy)[0] ?? site.district)?.trim();
 }
 
-export function getSiteLocationLabel(sites: Site[]): string {
+export function getSitesLocationLabel(sites: Site[]): string {
     return Object.keys(sites[0]?.locationHierarchy ?? {})[0] ?? 'District';
 }

--- a/src/features/annotation/components/task-details/specimen-image-viewer.tsx
+++ b/src/features/annotation/components/task-details/specimen-image-viewer.tsx
@@ -60,13 +60,19 @@ export default function SpecimenImageViewer({
                         {site ? (
                             <Fragment>
                                 <p className="text-sm font-medium">
-                                    {Object.values(site.locationHierarchy).length > 0
-                                        ? Object.values(site.locationHierarchy).slice(-2).join(', ')
+                                    {Object.values(site.locationHierarchy)
+                                        .length > 0
+                                        ? Object.values(site.locationHierarchy)
+                                              .slice(-2)
+                                              .join(', ')
                                         : `House #${site.houseNumber}, ${site.villageName}`}
                                 </p>
                                 <p className="text-muted-foreground text-sm">
-                                    {Object.values(site.locationHierarchy).length > 0
-                                        ? Object.values(site.locationHierarchy).slice(0, -2).join(', ')
+                                    {Object.values(site.locationHierarchy)
+                                        .length > 0
+                                        ? Object.values(site.locationHierarchy)
+                                              .slice(0, -2)
+                                              .join(', ')
                                         : `${site.subCounty}, ${site.district}`}
                                 </p>
                             </Fragment>

--- a/src/features/annotation/components/task-details/specimen-image-viewer.tsx
+++ b/src/features/annotation/components/task-details/specimen-image-viewer.tsx
@@ -60,11 +60,14 @@ export default function SpecimenImageViewer({
                         {site ? (
                             <Fragment>
                                 <p className="text-sm font-medium">
-                                    House #{site.houseNumber},{' '}
-                                    {site.villageName}
+                                    {Object.values(site.locationHierarchy).length > 0
+                                        ? Object.values(site.locationHierarchy).slice(-2).join(', ')
+                                        : `House #${site.houseNumber}, ${site.villageName}`}
                                 </p>
                                 <p className="text-muted-foreground text-sm">
-                                    {site.subCounty}, {site.district}
+                                    {Object.values(site.locationHierarchy).length > 0
+                                        ? Object.values(site.locationHierarchy).slice(0, -2).join(', ')
+                                        : `${site.subCounty}, ${site.district}`}
                                 </p>
                             </Fragment>
                         ) : (

--- a/src/features/operations/components/site-list/operations-site-hierarchy.tsx
+++ b/src/features/operations/components/site-list/operations-site-hierarchy.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { Site } from '@/api/site/validation/site-schema';
+import { getSiteTopLevelLocation } from '@/api/site/utils';
 import { Badge } from '@/components/ui/badge';
 import {
     Collapsible,
@@ -23,13 +24,36 @@ function getCompletenessBackgroundColor(
     return 'bg-destructive/10 hover:bg-destructive/20';
 }
 
-const HIERARCHY_LEVELS = [
+const LEGACY_HIERARCHY_LEVELS = [
     { key: 'subCounty', label: 'Subcounty' },
     { key: 'healthCenter', label: 'Health Center' },
     { key: 'parish', label: 'Parish' },
     { key: 'villageName', label: 'Village' },
     { key: 'houseNumber', label: 'House' },
-] as const;
+];
+
+export function getHierarchyLevels(
+    sites: Site[],
+): { key: string; label: string }[] {
+    const firstSite = sites[0];
+    if (!firstSite) return LEGACY_HIERARCHY_LEVELS;
+
+    const hierarchyKeys = Object.keys(firstSite.locationHierarchy);
+    if (hierarchyKeys.length > 0) {
+        return hierarchyKeys.slice(1).map(key => ({ key, label: key }));
+    }
+
+    return LEGACY_HIERARCHY_LEVELS;
+}
+
+function getSiteValueAtLevel(site: Site, levelKey: string): string | undefined {
+    const hierarchyKeys = Object.keys(site.locationHierarchy);
+    if (hierarchyKeys.length > 0) {
+        return site.locationHierarchy[levelKey];
+    }
+    return (site as Record<string, unknown>)[levelKey] as string | undefined;
+}
+
 
 interface SiteHierarchyProps {
     sites: Site[];
@@ -38,6 +62,7 @@ interface SiteHierarchyProps {
     siteIdToSessionCounts: Map<number, number>;
     expandedSitePaths: Set<string>;
     onToggle: (path: string) => void;
+    hierarchyLevels: { key: string; label: string }[];
 }
 
 export default function SiteHierarchy({
@@ -47,14 +72,16 @@ export default function SiteHierarchy({
     siteIdToSessionCounts,
     expandedSitePaths,
     onToggle,
+    hierarchyLevels,
 }: SiteHierarchyProps) {
-    const currentLevel = HIERARCHY_LEVELS[depth];
-    const isLeafLevel = depth === HIERARCHY_LEVELS.length - 1;
+    const currentLevel = hierarchyLevels[depth];
+    const isLeafLevel = depth === hierarchyLevels.length - 1;
 
     const sortedLocationEntries = useMemo(() => {
         if (!currentLevel) return [];
         const grouped = sites.reduce<Record<string, Site[]>>((groups, site) => {
-            const locationName = site[currentLevel.key] ?? 'Unknown';
+            const locationName =
+                getSiteValueAtLevel(site, currentLevel.key) ?? 'Unknown';
             groups[locationName] ??= [];
             groups[locationName].push(site);
             return groups;
@@ -75,7 +102,7 @@ export default function SiteHierarchy({
                     return (
                         <Link
                             key={site.siteId}
-                            href={`/operations/${site.district}/${site.siteId}`}
+                            href={`/operations/${getSiteTopLevelLocation(site)}/${site.siteId}`}
                         >
                             <div className="group hover:bg-muted/50 flex items-center justify-between rounded-md px-3 py-2 transition-colors">
                                 <div className="flex items-center gap-3">
@@ -95,7 +122,10 @@ export default function SiteHierarchy({
                                         />
                                     </div>
                                     <span className="text-sm">
-                                        {site[currentLevel.key] ?? 'Unknown'}
+                                        {getSiteValueAtLevel(
+                                            site,
+                                            currentLevel.key,
+                                        ) ?? 'Unknown'}
                                     </span>
                                 </div>
                                 <Badge
@@ -179,6 +209,7 @@ export default function SiteHierarchy({
                                         }
                                         expandedSitePaths={expandedSitePaths}
                                         onToggle={onToggle}
+                                        hierarchyLevels={hierarchyLevels}
                                     />
                                 </div>
                             </CollapsibleContent>

--- a/src/features/operations/components/site-list/operations-site-hierarchy.tsx
+++ b/src/features/operations/components/site-list/operations-site-hierarchy.tsx
@@ -24,28 +24,6 @@ function getCompletenessBackgroundColor(
     return 'bg-destructive/10 hover:bg-destructive/20';
 }
 
-const LEGACY_HIERARCHY_LEVELS = [
-    { key: 'subCounty', label: 'Subcounty' },
-    { key: 'healthCenter', label: 'Health Center' },
-    { key: 'parish', label: 'Parish' },
-    { key: 'villageName', label: 'Village' },
-    { key: 'houseNumber', label: 'House' },
-];
-
-export function getHierarchyLevels(
-    sites: Site[],
-): { key: string; label: string }[] {
-    const firstSite = sites[0];
-    if (!firstSite) return LEGACY_HIERARCHY_LEVELS;
-
-    const hierarchyKeys = Object.keys(firstSite.locationHierarchy);
-    if (hierarchyKeys.length > 0) {
-        return hierarchyKeys.slice(1).map(key => ({ key, label: key }));
-    }
-
-    return LEGACY_HIERARCHY_LEVELS;
-}
-
 function getSiteValueAtLevel(site: Site, levelKey: string): string | undefined {
     const hierarchyKeys = Object.keys(site.locationHierarchy);
     if (hierarchyKeys.length > 0) {

--- a/src/features/operations/components/site-list/operations-site-hierarchy.tsx
+++ b/src/features/operations/components/site-list/operations-site-hierarchy.tsx
@@ -54,7 +54,6 @@ function getSiteValueAtLevel(site: Site, levelKey: string): string | undefined {
     return (site as Record<string, unknown>)[levelKey] as string | undefined;
 }
 
-
 interface SiteHierarchyProps {
     sites: Site[];
     depth: number;

--- a/src/features/operations/components/site-list/operations-site-list-header.tsx
+++ b/src/features/operations/components/site-list/operations-site-list-header.tsx
@@ -54,7 +54,9 @@ export default function OperationsDataHeader({
                     onValueChange={onDistrictChange}
                 >
                     <SelectTrigger className="w-52">
-                        <SelectValue placeholder={`Select a ${locationLabel.toLowerCase()}`} />
+                        <SelectValue
+                            placeholder={`Select a ${locationLabel.toLowerCase()}`}
+                        />
                     </SelectTrigger>
                     <SelectContent>
                         <SelectGroup>

--- a/src/features/operations/components/site-list/operations-site-list-header.tsx
+++ b/src/features/operations/components/site-list/operations-site-list-header.tsx
@@ -25,6 +25,7 @@ interface OperationsDataHeaderProps {
     districts: string[];
     selectedDistrict: string;
     onDistrictChange: (district: string) => void;
+    locationLabel: string;
     dateRange: DateRange | undefined;
     onDateRangeChange: (dateRange: DateRange | undefined) => void;
     onClearDateRange: () => void;
@@ -38,6 +39,7 @@ export default function OperationsDataHeader({
     districts,
     selectedDistrict,
     onDistrictChange,
+    locationLabel,
     dateRange,
     onDateRangeChange,
     onClearDateRange,
@@ -52,11 +54,11 @@ export default function OperationsDataHeader({
                     onValueChange={onDistrictChange}
                 >
                     <SelectTrigger className="w-52">
-                        <SelectValue placeholder="Select a district" />
+                        <SelectValue placeholder={`Select a ${locationLabel.toLowerCase()}`} />
                     </SelectTrigger>
                     <SelectContent>
                         <SelectGroup>
-                            <SelectLabel>District</SelectLabel>
+                            <SelectLabel>{locationLabel}</SelectLabel>
                             {districts.map(district => (
                                 <SelectItem key={district} value={district}>
                                     {district}

--- a/src/features/operations/components/site-list/operations-site-list.tsx
+++ b/src/features/operations/components/site-list/operations-site-list.tsx
@@ -4,7 +4,7 @@ import { useGetAllSessions } from '@/api/session/hooks/use-get-all-sessions';
 import type { Site } from '@/api/site/validation/site-schema';
 import { useMemo, useState } from 'react';
 import { Microscope } from 'lucide-react';
-import SiteHierarchy from './operations-site-hierarchy';
+import SiteHierarchy, { getHierarchyLevels } from './operations-site-hierarchy';
 
 interface OperationsSiteListProps {
     sites: Site[];
@@ -32,6 +32,8 @@ export default function OperationsSiteList({
             },
             { enabled: !!district },
         );
+
+    const hierarchyLevels = useMemo(() => getHierarchyLevels(sites), [sites]);
 
     const siteIdToSessionCounts = useMemo(() => {
         const counts = new Map<number, number>();
@@ -91,6 +93,7 @@ export default function OperationsSiteList({
             siteIdToSessionCounts={siteIdToSessionCounts}
             expandedSitePaths={expandedSitePaths}
             onToggle={toggleSiteRow}
+            hierarchyLevels={hierarchyLevels}
         />
     );
 }

--- a/src/features/operations/components/site-list/operations-site-list.tsx
+++ b/src/features/operations/components/site-list/operations-site-list.tsx
@@ -4,7 +4,8 @@ import { useGetAllSessions } from '@/api/session/hooks/use-get-all-sessions';
 import type { Site } from '@/api/site/validation/site-schema';
 import { useMemo, useState } from 'react';
 import { Microscope } from 'lucide-react';
-import SiteHierarchy, { getHierarchyLevels } from './operations-site-hierarchy';
+import SiteHierarchy from './operations-site-hierarchy';
+import { getHierarchyLevels } from '@/api/site/utils';
 
 interface OperationsSiteListProps {
     sites: Site[];

--- a/src/features/operations/components/site-list/page-client/operations-site-list-page-client.tsx
+++ b/src/features/operations/components/site-list/page-client/operations-site-list-page-client.tsx
@@ -4,7 +4,10 @@ import { useState } from 'react';
 import type { DateRange } from 'react-day-picker';
 import { format } from 'date-fns';
 import { useGetUserPermissions } from '@/api/user/hooks/use-get-user-permissions';
-import { getSiteTopLevelLocation, getSiteLocationLabel } from '@/api/site/utils';
+import {
+    getSiteTopLevelLocation,
+    getSiteLocationLabel,
+} from '@/api/site/utils';
 import PageShell from '@/components/layout/page-shell';
 import { Card, CardContent } from '@/components/ui/card';
 import { Microscope } from 'lucide-react';

--- a/src/features/operations/components/site-list/page-client/operations-site-list-page-client.tsx
+++ b/src/features/operations/components/site-list/page-client/operations-site-list-page-client.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import type { DateRange } from 'react-day-picker';
 import { format } from 'date-fns';
 import { useGetUserPermissions } from '@/api/user/hooks/use-get-user-permissions';
+import { getSiteTopLevelLocation, getSiteLocationLabel } from '@/api/site/utils';
 import PageShell from '@/components/layout/page-shell';
 import { Card, CardContent } from '@/components/ui/card';
 import { Microscope } from 'lucide-react';
@@ -40,17 +41,19 @@ export default function OperationsSiteListPageClient() {
     const accessibleSites =
         getUserPermissionsResult.data.permissions.sites.canAccessSites;
 
+    const locationLabel = getSiteLocationLabel(accessibleSites);
+
     const filteredAccessibleSites = selectedDistrict
         ? accessibleSites.filter(
-              site => site.district?.trim() === selectedDistrict,
+              site => getSiteTopLevelLocation(site) === selectedDistrict,
           )
         : accessibleSites;
 
     const accessibleDistricts = [
         ...new Set(
             accessibleSites
-                .map(site => site.district?.trim())
-                .filter((district): district is string => Boolean(district)),
+                .map(site => getSiteTopLevelLocation(site))
+                .filter((location): location is string => Boolean(location)),
         ),
     ].sort();
 
@@ -66,6 +69,7 @@ export default function OperationsSiteListPageClient() {
                         districts={accessibleDistricts}
                         selectedDistrict={selectedDistrict}
                         onDistrictChange={setSelectedDistrict}
+                        locationLabel={locationLabel}
                         dateRange={dateRange}
                         onDateRangeChange={setDateRange}
                         onClearDateRange={() => setDateRange(undefined)}

--- a/src/features/operations/components/site-list/page-client/operations-site-list-page-client.tsx
+++ b/src/features/operations/components/site-list/page-client/operations-site-list-page-client.tsx
@@ -6,7 +6,7 @@ import { format } from 'date-fns';
 import { useGetUserPermissions } from '@/api/user/hooks/use-get-user-permissions';
 import {
     getSiteTopLevelLocation,
-    getSiteLocationLabel,
+    getSitesLocationLabel,
 } from '@/api/site/utils';
 import PageShell from '@/components/layout/page-shell';
 import { Card, CardContent } from '@/components/ui/card';

--- a/src/features/operations/components/site-list/page-client/operations-site-list-page-client.tsx
+++ b/src/features/operations/components/site-list/page-client/operations-site-list-page-client.tsx
@@ -44,7 +44,7 @@ export default function OperationsSiteListPageClient() {
     const accessibleSites =
         getUserPermissionsResult.data.permissions.sites.canAccessSites;
 
-    const locationLabel = getSiteLocationLabel(accessibleSites);
+    const locationLabel = getSitesLocationLabel(accessibleSites);
 
     const filteredAccessibleSites = selectedDistrict
         ? accessibleSites.filter(

--- a/src/features/review/components/sites-list/page-client/review-sites-list-page-client.tsx
+++ b/src/features/review/components/sites-list/page-client/review-sites-list-page-client.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { useGetUserPermissions } from '@/api/user/hooks/use-get-user-permissions';
-import { getSiteTopLevelLocation, getSiteLocationLabel } from '@/api/site/utils';
+import {
+    getSiteTopLevelLocation,
+    getSiteLocationLabel,
+} from '@/api/site/utils';
 import PageShell from '@/components/layout/page-shell';
 import { Card, CardContent } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';

--- a/src/features/review/components/sites-list/page-client/review-sites-list-page-client.tsx
+++ b/src/features/review/components/sites-list/page-client/review-sites-list-page-client.tsx
@@ -3,7 +3,7 @@
 import { useGetUserPermissions } from '@/api/user/hooks/use-get-user-permissions';
 import {
     getSiteTopLevelLocation,
-    getSiteLocationLabel,
+    getSitesLocationLabel,
 } from '@/api/site/utils';
 import PageShell from '@/components/layout/page-shell';
 import { Card, CardContent } from '@/components/ui/card';
@@ -39,7 +39,7 @@ export default function ReviewSitesListPageClient() {
     const accessibleSites =
         getUserPermissionsResult.data.permissions.sites.canAccessSites;
 
-    const locationLabel = getSiteLocationLabel(accessibleSites);
+    const locationLabel = getSitesLocationLabel(accessibleSites);
 
     const accessibleDistricts = [
         ...new Set(

--- a/src/features/review/components/sites-list/page-client/review-sites-list-page-client.tsx
+++ b/src/features/review/components/sites-list/page-client/review-sites-list-page-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useGetUserPermissions } from '@/api/user/hooks/use-get-user-permissions';
+import { getSiteTopLevelLocation, getSiteLocationLabel } from '@/api/site/utils';
 import PageShell from '@/components/layout/page-shell';
 import { Card, CardContent } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
@@ -35,17 +36,19 @@ export default function ReviewSitesListPageClient() {
     const accessibleSites =
         getUserPermissionsResult.data.permissions.sites.canAccessSites;
 
+    const locationLabel = getSiteLocationLabel(accessibleSites);
+
     const accessibleDistricts = [
         ...new Set(
             accessibleSites
-                .map(site => site.district?.trim())
-                .filter((district): district is string => Boolean(district)),
+                .map(site => getSiteTopLevelLocation(site))
+                .filter((location): location is string => Boolean(location)),
         ),
     ].sort();
 
     const sitesInAccessibleDistrict = selectedDistrict
         ? accessibleSites.filter(
-              site => site.district?.trim() === selectedDistrict,
+              site => getSiteTopLevelLocation(site) === selectedDistrict,
           )
         : [];
 
@@ -61,6 +64,7 @@ export default function ReviewSitesListPageClient() {
                         districts={accessibleDistricts}
                         selectedDistrict={selectedDistrict}
                         onDistrictChange={setSelectedDistrict}
+                        locationLabel={locationLabel}
                         selectedMonth={selectedMonth}
                         onMonthChange={setSelectedMonth}
                     />

--- a/src/features/review/components/sites-list/review-site-card.tsx
+++ b/src/features/review/components/sites-list/review-site-card.tsx
@@ -4,6 +4,7 @@ import type { Site } from '@/api/site/validation/site-schema';
 import type { SessionState } from '@/api/session/validation/session-schema';
 import { Badge } from '@/components/ui/badge';
 import { ChevronRight, Lock, MapPin } from 'lucide-react';
+import { getSiteTopLevelLocation } from '@/api/site/utils';
 import Link from 'next/link';
 
 interface ReviewSiteCardProps {
@@ -47,7 +48,9 @@ export default function ReviewSiteCard({
                         </div>
                         <div>
                             <p className="font-medium">
-                                {site.houseNumber ?? `Site ${site.siteId}`}
+                                {site.name ??
+                                    site.houseNumber ??
+                                    `Site ${site.siteId}`}
                             </p>
                             <p className="text-muted-foreground text-sm">
                                 {sessionCount} session
@@ -68,8 +71,10 @@ export default function ReviewSiteCard({
         );
     }
 
+    const topLevelLocation = getSiteTopLevelLocation(site);
+
     return (
-        <Link href={`/review/${site.district}/${site.siteId}`}>
+        <Link href={`/review/${topLevelLocation}/${site.siteId}`}>
             <div className="border-border/50 bg-card/50 hover:bg-muted/50 flex items-center justify-between gap-4 rounded-lg border p-4 transition-colors">
                 <div className="flex items-center gap-3">
                     <div className="bg-primary/10 flex h-10 w-10 shrink-0 items-center justify-center rounded-full">
@@ -77,7 +82,9 @@ export default function ReviewSiteCard({
                     </div>
                     <div>
                         <p className="font-medium">
-                            {site.houseNumber ?? `Site ${site.siteId}`}
+                            {site.name ??
+                                site.houseNumber ??
+                                `Site ${site.siteId}`}
                         </p>
                         <p className="text-muted-foreground text-sm">
                             {sessionCount} session{sessionCount !== 1 && 's'}

--- a/src/features/review/components/sites-list/review-sites-list-header.tsx
+++ b/src/features/review/components/sites-list/review-sites-list-header.tsx
@@ -15,6 +15,7 @@ interface ReviewSiteListHeaderProps {
     districts: string[];
     selectedDistrict: string;
     onDistrictChange: (district: string) => void;
+    locationLabel: string;
     selectedMonth: Date;
     onMonthChange: (month: Date) => void;
 }
@@ -23,6 +24,7 @@ export default function ReviewSitesListHeader({
     districts,
     selectedDistrict,
     onDistrictChange,
+    locationLabel,
     selectedMonth,
     onMonthChange,
 }: ReviewSiteListHeaderProps) {
@@ -30,11 +32,11 @@ export default function ReviewSitesListHeader({
         <div className="flex items-center justify-between">
             <Select value={selectedDistrict} onValueChange={onDistrictChange}>
                 <SelectTrigger className="w-52">
-                    <SelectValue placeholder="Select a district" />
+                    <SelectValue placeholder={`Select a ${locationLabel.toLowerCase()}`} />
                 </SelectTrigger>
                 <SelectContent>
                     <SelectGroup>
-                        <SelectLabel>District</SelectLabel>
+                        <SelectLabel>{locationLabel}</SelectLabel>
                         {districts.map(district => (
                             <SelectItem key={district} value={district}>
                                 {district}

--- a/src/features/review/components/sites-list/review-sites-list-header.tsx
+++ b/src/features/review/components/sites-list/review-sites-list-header.tsx
@@ -32,7 +32,9 @@ export default function ReviewSitesListHeader({
         <div className="flex items-center justify-between">
             <Select value={selectedDistrict} onValueChange={onDistrictChange}>
                 <SelectTrigger className="w-52">
-                    <SelectValue placeholder={`Select a ${locationLabel.toLowerCase()}`} />
+                    <SelectValue
+                        placeholder={`Select a ${locationLabel.toLowerCase()}`}
+                    />
                 </SelectTrigger>
                 <SelectContent>
                     <SelectGroup>


### PR DESCRIPTION
### Replace Uganda location fields with generic location hierarchy

All hardcoded Uganda location fields (`district`, `subCounty`, `villageName`, etc.) are now treated as legacy fallbacks.   
The app now reads from `locationHierarchy`, a generic key/value map for new-schema programs and falls back to the flat fields for existing Uganda sites. (It is currently backwards compatible)

### Changes
- New `src/api/site/utils.ts` with shared helpers for reading top-level location and label
- `operations-site-hierarchy.tsx`: hierarchy tree now derived dynamically from `locationHierarchy` keys instead of hardcoded Uganda levels
- Both page-clients and headers: district dropdown now schema-agnostic, label reflects actual location type name
- `review-site-card.tsx` and `specimen-image-viewer.tsx`: display logic updated with legacy fallbacks
