### PR TITLE
VCV-147: Implement report export endpoint and UI

### DIFF
--- a/src/api/session/get-sessions-report.ts
+++ b/src/api/session/get-sessions-report.ts
@@ -1,0 +1,53 @@
+import {
+    getSessionsReportQueryParamsSchema,
+    type GetSessionsReportQueryParams,
+} from '@/api/session/validation/get-sessions-report-schema';
+import { constructQueryString } from '@/lib/network/construct-query-string';
+import { constructUrl } from '@/lib/network/construct-url';
+import {
+    statusToNetworkErrorKind,
+    type NetworkError,
+} from '@/lib/network/network-error';
+import { err, ok, type Result } from '@/lib/result/result';
+import { NextResponse } from 'next/server';
+
+export async function getSessionsReport(
+    accessToken: string,
+    queryParams?: GetSessionsReportQueryParams,
+): Promise<Result<NextResponse, NetworkError>> {
+    const queryString = constructQueryString<GetSessionsReportQueryParams>(
+        queryParams,
+        getSessionsReportQueryParamsSchema,
+    );
+
+    const response = await fetch(
+        constructUrl(`/sessions/report${queryString}`),
+        {
+            method: 'GET',
+            headers: {
+                Authorization: `Bearer ${accessToken}`,
+            },
+        },
+    );
+
+    if (!response.ok) {
+        return err({
+            kind: statusToNetworkErrorKind(response.status),
+            status: response.status,
+        });
+    }
+
+    return ok(
+        new NextResponse(response.body, {
+            status: response.status,
+            headers: {
+                'Content-Type':
+                    response.headers.get('content-type') ??
+                    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                'Content-Disposition':
+                    response.headers.get('content-disposition') ??
+                    'attachment; filename="sessions_report.xlsx"',
+            },
+        }),
+    );
+}

--- a/src/api/session/validation/get-sessions-report-schema.ts
+++ b/src/api/session/validation/get-sessions-report-schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { sessionTypeSchema } from './session-schema';
+
+export const getSessionsReportQueryParamsSchema = z.object({
+    startDate: z.string().optional(),
+    endDate: z.string().optional(),
+    sessionType: sessionTypeSchema.optional(),
+    programId: z.coerce.number().optional(),
+    districts: z.string().optional(),
+    siteIds: z.string().optional(),
+});
+
+export type GetSessionsReportQueryParams = z.infer<
+    typeof getSessionsReportQueryParamsSchema
+>;

--- a/src/app/api/sessions/report/route.ts
+++ b/src/app/api/sessions/report/route.ts
@@ -1,0 +1,36 @@
+import { getSessionsReport } from '@/api/session/get-sessions-report';
+import { getSessionsReportQueryParamsSchema } from '@/api/session/validation/get-sessions-report-schema';
+import { withAuthSession } from '@/lib/auth-session/with-auth-session';
+import { err } from '@/lib/result/result';
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request) {
+    const url = new URL(request.url);
+    const queryParams = Object.fromEntries(url.searchParams.entries());
+
+    const parsedQueryParams =
+        getSessionsReportQueryParamsSchema.safeParse(queryParams);
+    if (!parsedQueryParams.success) {
+        return NextResponse.json(
+            err({
+                kind: 'client',
+                status: 400,
+                message: 'Invalid query parameters',
+            }),
+            { status: 400 },
+        );
+    }
+
+    const authorizedGetSessionsReportResult =
+        await withAuthSession<NextResponse>(accessToken =>
+            getSessionsReport(accessToken, parsedQueryParams.data),
+        );
+
+    if (!authorizedGetSessionsReportResult.ok) {
+        return NextResponse.json(authorizedGetSessionsReportResult, {
+            status: authorizedGetSessionsReportResult.error.status ?? 400,
+        });
+    }
+
+    return authorizedGetSessionsReportResult.data;
+}

--- a/src/features/operations/components/export/export-dialog.tsx
+++ b/src/features/operations/components/export/export-dialog.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import {
+    type GetSessionsReportQueryParams,
+    getSessionsReportQueryParamsSchema,
+} from '@/api/session/validation/get-sessions-report-schema';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { constructQueryString } from '@/lib/network/construct-query-string';
+import {
+    networkErrorMessage,
+    type NetworkError,
+} from '@/lib/network/network-error';
+import type { Result } from '@/lib/result/result';
+import { Download, Loader2 } from 'lucide-react';
+import { useState } from 'react';
+
+interface ExportDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    programId: number;
+    district: string;
+    startDate?: string;
+    endDate?: string;
+}
+
+export default function ExportDialog({
+    open,
+    onOpenChange,
+    programId,
+    district,
+    startDate,
+    endDate,
+}: ExportDialogProps) {
+    const [isExporting, setIsExporting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    function handleOpenChange(nextOpen: boolean) {
+        if (!nextOpen) setError(null);
+        onOpenChange(nextOpen);
+    }
+
+    async function handleExport() {
+        setIsExporting(true);
+        setError(null);
+
+        try {
+            const queryString =
+                constructQueryString<GetSessionsReportQueryParams>(
+                    {
+                        startDate,
+                        endDate,
+                        sessionType: 'SURVEILLANCE',
+                        programId: programId,
+                        districts: district,
+                    },
+                    getSessionsReportQueryParamsSchema,
+                );
+
+            const response = await fetch(`/api/sessions/report${queryString}`, {
+                method: 'GET',
+                credentials: 'include',
+            });
+
+            if (!response.ok) {
+                const getSessionsReportErrorResult: Result<
+                    never,
+                    NetworkError
+                > = await response.json();
+                setError(
+                    getSessionsReportErrorResult.ok
+                        ? 'An unexpected error occurred. Please try again.'
+                        : networkErrorMessage(
+                              getSessionsReportErrorResult.error,
+                          ),
+                );
+                return;
+            }
+
+            const blob = await response.blob();
+            const url = URL.createObjectURL(blob);
+
+            const anchor = document.createElement('a');
+            anchor.href = url;
+            anchor.download = `${district}-report-${startDate}-to-${endDate}.xlsx`;
+            document.body.appendChild(anchor);
+            anchor.click();
+            anchor.remove();
+            URL.revokeObjectURL(url);
+
+            handleOpenChange(false);
+        } catch {
+            setError('An unexpected error occurred. Please try again.');
+        } finally {
+            setIsExporting(false);
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Export Report</DialogTitle>
+                    <DialogDescription>
+                        This will download session data for{' '}
+                        <span className="text-foreground font-medium">
+                            {district}
+                        </span>{' '}
+                        from{' '}
+                        <span className="text-foreground font-medium">
+                            {startDate}
+                        </span>{' '}
+                        to{' '}
+                        <span className="text-foreground font-medium">
+                            {endDate}
+                        </span>
+                        .
+                    </DialogDescription>
+                </DialogHeader>
+
+                {error && <p className="text-destructive text-sm">{error}</p>}
+
+                <DialogFooter>
+                    <Button
+                        variant="outline"
+                        onClick={() => handleOpenChange(false)}
+                        disabled={isExporting}
+                    >
+                        Cancel
+                    </Button>
+                    <Button onClick={handleExport} disabled={isExporting}>
+                        {isExporting ? (
+                            <Loader2 className="animate-spin" />
+                        ) : (
+                            <Download />
+                        )}
+                        {isExporting ? 'Exporting…' : 'Export'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/features/operations/components/layout/operations-header.tsx
+++ b/src/features/operations/components/layout/operations-header.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@/components/ui/button';
 import MonthPicker from '@/components/ui/month-picker';
 import {
     Select,
@@ -12,6 +13,7 @@ import {
 } from '@/components/ui/select';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type { OperationsTab } from '@/features/operations/components/page-client/operations-page-client';
+import { Download } from 'lucide-react';
 
 interface OperationsHeaderProps {
     tabs: readonly { value: OperationsTab; label: string }[];
@@ -22,6 +24,7 @@ interface OperationsHeaderProps {
     onDistrictChange: (district: string) => void;
     selectedMonth: Date;
     onMonthChange: (month: Date) => void;
+    onExportClick: () => void;
 }
 
 export default function OperationsHeader({
@@ -33,6 +36,7 @@ export default function OperationsHeader({
     onDistrictChange,
     selectedMonth,
     onMonthChange,
+    onExportClick,
 }: OperationsHeaderProps) {
     return (
         <div className="space-y-4">
@@ -56,11 +60,22 @@ export default function OperationsHeader({
                     </SelectContent>
                 </Select>
 
-                <MonthPicker
-                    selectedMonth={selectedMonth}
-                    onMonthChange={onMonthChange}
-                    maxDate={new Date()}
-                />
+                <div className="flex items-center gap-2">
+                    <MonthPicker
+                        selectedMonth={selectedMonth}
+                        onMonthChange={onMonthChange}
+                        maxDate={new Date()}
+                    />
+
+                    <Button
+                        variant="default"
+                        disabled={!selectedDistrict}
+                        onClick={onExportClick}
+                    >
+                        <Download className="h-4 w-4" />
+                        Export Data
+                    </Button>
+                </div>
             </div>
 
             <Tabs

--- a/src/features/operations/components/page-client/operations-page-client.tsx
+++ b/src/features/operations/components/page-client/operations-page-client.tsx
@@ -11,6 +11,7 @@ import OperationsSiteList from '@/features/operations/components/site-list/opera
 import { Separator } from '@/components/ui/separator';
 import OperationsHeader from '@/features/operations/components/layout/operations-header';
 import OperationsAiPerformanceTab from '@/features/operations/components/ai-performance/operations-ai-performance-tab';
+import ExportDialog from '@/features/operations/components/export/export-dialog';
 
 const OPERATIONS_TABS = [
     { value: 'sites', label: 'SITES' },
@@ -26,6 +27,7 @@ export default function OperationsPageClient() {
     const [selectedMonth, setSelectedMonth] = useState(() =>
         startOfMonth(new Date()),
     );
+    const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
 
     const {
         data: getUserPermissionsResult,
@@ -95,6 +97,7 @@ export default function OperationsPageClient() {
                         onDistrictChange={setSelectedDistrict}
                         selectedMonth={selectedMonth}
                         onMonthChange={setSelectedMonth}
+                        onExportClick={() => setIsExportDialogOpen(true)}
                     />
 
                     <Separator />
@@ -126,6 +129,15 @@ export default function OperationsPageClient() {
                     )}
                 </CardContent>
             </Card>
+
+            <ExportDialog
+                open={isExportDialogOpen}
+                onOpenChange={setIsExportDialogOpen}
+                programId={getUserPermissionsResult.data.programId}
+                district={selectedDistrict}
+                startDate={startDate}
+                endDate={endDate}
+            />
         </PageShell>
     );
 }

--- a/src/features/operations/components/site-list/operations-site-list.tsx
+++ b/src/features/operations/components/site-list/operations-site-list.tsx
@@ -27,6 +27,7 @@ export default function OperationsSiteList({
             district,
             ...(startDate && { startDate }),
             ...(endDate && { endDate }),
+            type: 'SURVEILLANCE',
         });
 
     const siteIdToSessionCounts = useMemo(() => {

--- a/src/features/review/components/sites-list/review-sites-list.tsx
+++ b/src/features/review/components/sites-list/review-sites-list.tsx
@@ -39,7 +39,7 @@ export default function ReviewSitesList({
 
     const { data: getAllSessionsResult, isPending: isGetAllSessionsPending } =
         useGetAllSessions(
-            { district, startDate, endDate },
+            { district, startDate, endDate, type: 'SURVEILLANCE' },
             { enabled: !!district },
         );
 


### PR DESCRIPTION
This pull request introduces a complete end-to-end feature for exporting session data as an Excel report from the Operations page. The main changes include backend API endpoints for generating and serving the report, frontend UI components for triggering the export, and integration of these components into the Operations dashboard.

**Export Sessions Report Feature**

_Backend API and Validation:_
* Added a new API endpoint (`src/app/api/sessions/report/route.ts`) that validates query parameters, checks authentication, and returns an Excel file containing session data.
* Introduced a schema and type definition for report query parameters in `get-sessions-report-schema.ts` to ensure robust validation and type safety.
* Implemented the core logic for fetching and formatting the report response in `get-sessions-report.ts`.

_Frontend UI and Integration:_
* Added an `ExportDialog` component that handles the export flow, including parameter construction, error handling, and file download.
* Integrated an "Export Data" button into the `OperationsHeader` and connected it to the export dialog, making the export feature accessible from the dashboard. [[1]](diffhunk://#diff-b4d157916103d4dee0158e0b6355a8cf2c6351d1b46f27490a8415c7b6c21995R3) [[2]](diffhunk://#diff-b4d157916103d4dee0158e0b6355a8cf2c6351d1b46f27490a8415c7b6c21995R16) [[3]](diffhunk://#diff-b4d157916103d4dee0158e0b6355a8cf2c6351d1b46f27490a8415c7b6c21995R27) [[4]](diffhunk://#diff-b4d157916103d4dee0158e0b6355a8cf2c6351d1b46f27490a8415c7b6c21995R39) [[5]](diffhunk://#diff-b4d157916103d4dee0158e0b6355a8cf2c6351d1b46f27490a8415c7b6c21995R63-R78) [[6]](diffhunk://#diff-8d8f11720a069f9582f5e10d67018be692013452e989a3ea5fadfbc32e427455R14) [[7]](diffhunk://#diff-8d8f11720a069f9582f5e10d67018be692013452e989a3ea5fadfbc32e427455R30) [[8]](diffhunk://#diff-8d8f11720a069f9582f5e10d67018be692013452e989a3ea5fadfbc32e427455R100) [[9]](diffhunk://#diff-8d8f11720a069f9582f5e10d67018be692013452e989a3ea5fadfbc32e427455R132-R140)

**Other Related Updates**

* Updated session data fetching in site and review lists to consistently use the `SURVEILLANCE` session type, aligning with the export logic. [[1]](diffhunk://#diff-c63fe22af468c26b0f3ef98e5b7da15471a75d2ef9851ccefa7f40cc2a3d9f8dR30) [[2]](diffhunk://#diff-67586cbcca073dc99c6cde53fcfebc58318fda5de7b66c4b0b04ddd9ae21fe96L42-R42)