### PR TITLE
VCV-189: Add axis labels to area charts

### DIFF
--- a/src/features/operations/components/page-client/operations-page-client.tsx
+++ b/src/features/operations/components/page-client/operations-page-client.tsx
@@ -12,7 +12,7 @@ import OperationsAiPerformance from '@/features/operations/components/ai-perform
 import OperationsGeographicalSummary from '@/features/operations/components/geographical-summary/operations-geographical-summary';
 import { SkeletonList } from '@/components/ui/skeleton-list';
 import ExportDialog from '@/features/operations/components/export/export-dialog';
-import OperationsSpeciesComposition from '../species-composition/operations-species-composition';
+import OperationsSpecimenComposition from '../specimen-composition/operations-specimen-composition';
 import OperationsFieldUserCompliance from '@/features/operations/components/field-user-compliance/operations-field-user-compliance';
 import type { UserPermissions } from '@/api/user/validation/user-permissions-schema';
 import { useLocationSelection } from '@/lib/location/use-location-selection';
@@ -24,8 +24,8 @@ const OPERATIONS_TABS = [
         shouldRender: () => true,
     },
     {
-        value: 'species-composition',
-        label: 'SPECIES COMPOSITION',
+        value: 'specimen-composition',
+        label: 'SPECIMEN COMPOSITION',
         shouldRender: () => true,
     },
     {
@@ -141,8 +141,8 @@ export default function OperationsPageClient() {
                         </div>
                     ) : (
                         <Fragment>
-                            {activeTab === 'species-composition' && (
-                                <OperationsSpeciesComposition
+                            {activeTab === 'specimen-composition' && (
+                                <OperationsSpecimenComposition
                                     locationQueryParam={locationQueryParam}
                                     startDate={startDate}
                                     endDate={endDate}

--- a/src/features/operations/components/specimen-composition/composition-chart-pair.tsx
+++ b/src/features/operations/components/specimen-composition/composition-chart-pair.tsx
@@ -123,14 +123,40 @@ export default function CompositionChartPair({
                             config={specimenChartConfig}
                             className="h-full w-full"
                         >
-                            <AreaChart data={specimenCountsByMonth}>
+                            <AreaChart
+                                data={specimenCountsByMonth}
+                                margin={{
+                                    top: 8,
+                                    right: 12,
+                                    bottom: 32,
+                                    left: 12,
+                                }}
+                            >
                                 <CartesianGrid strokeDasharray="3 3" />
                                 <XAxis
                                     dataKey="month"
                                     tickLine={false}
                                     axisLine={false}
-                                />
-                                <YAxis tickLine={false} axisLine={false} />
+                                >
+                                    <Label
+                                        value="Month"
+                                        position="bottom"
+                                        className="fill-muted-foreground text-sm font-bold"
+                                    />
+                                </XAxis>
+                                <YAxis
+                                    tickLine={false}
+                                    axisLine={false}
+                                    width={44}
+                                >
+                                    <Label
+                                        value="Specimen Count"
+                                        angle={-90}
+                                        position="left"
+                                        className="fill-muted-foreground text-sm font-bold"
+                                        style={{ textAnchor: 'middle' }}
+                                    />
+                                </YAxis>
                                 <ChartTooltip
                                     content={
                                         <ChartTooltipContent

--- a/src/features/operations/components/specimen-composition/operations-specimen-composition.tsx
+++ b/src/features/operations/components/specimen-composition/operations-specimen-composition.tsx
@@ -20,17 +20,17 @@ const COMPOSITION_SECTIONS: {
     { specimenClassificationAxis: 'abdomenStatus', title: 'Abdomen Status' },
 ];
 
-interface OperationsSpeciesCompositionProps {
+interface OperationsSpecimenCompositionProps {
     locationQueryParam: LocationQueryParam;
     startDate: string;
     endDate: string;
 }
 
-export default function OperationsSpeciesComposition({
+export default function OperationsSpecimenComposition({
     locationQueryParam,
     startDate,
     endDate,
-}: OperationsSpeciesCompositionProps) {
+}: OperationsSpecimenCompositionProps) {
     const locationFilter =
         'district' in locationQueryParam
             ? { districts: [locationQueryParam.district] }


### PR DESCRIPTION
This pull request updates the "Species Composition" feature to "Specimen Composition" across the operations UI, including renaming files, components, and tab labels for clarity and consistency. It also improves the chart display in the composition section with enhanced axis labeling and layout.

**Renaming and UI Consistency:**

* Renamed the `OperationsSpeciesComposition` component and related files to `OperationsSpecimenComposition`, and updated all imports and references accordingly. [[1]](diffhunk://#diff-8d8f11720a069f9582f5e10d67018be692013452e989a3ea5fadfbc32e427455L15-R15) [[2]](diffhunk://#diff-8d8f11720a069f9582f5e10d67018be692013452e989a3ea5fadfbc32e427455L144-R145) [[3]](diffhunk://#diff-1c3dd55cc786566d3a46860e4391ca17f7148f1fc3c0d7320204d75473d1b26bL23-R33)
* Updated the operations tab value and label from `'species-composition'` to `'specimen-composition'` to match the new terminology.

**Chart Improvements:**

* Enhanced the `AreaChart` in the composition chart pair by adding axis labels ("Month" for X-axis, "Specimen Count" for Y-axis), adjusting margins, and improving layout for better readability.