### PR TITLE
commit common claude files

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,5 @@
+settings.local.json
+prds/
+plans/
+projects/
+.DS_Store

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,57 @@
+# VectorVerify
+
+@.claude/docs/architecture.md @.claude/docs/best-practices.md
+@.claude/docs/schema.md
+
+## API Reference
+
+The live VectorCam API spec (always current — no local file needed):
+https://test.api.vectorcam.org/documentation/json
+
+Fetch this URL when you need endpoint details, request shapes, or response
+schemas.
+
+## Working with Claude
+
+- Always read the current state of a file before making changes. Never assume it
+  matches a previous version from earlier in the conversation.
+
+## Code Standards
+
+**Architecture**
+
+- Data fetching follows: server function → BFF route (`/api/…/route.ts`) →
+  TanStack Query hook (`useGet…`)
+- Client components never call backend APIs directly
+- Wrap all API responses in `Result<T, E>` — never use try/catch in the UI layer
+- Validate all external data with Zod schemas; derive TypeScript types from them
+
+**File placement**
+
+- Shared UI primitives → `src/components/ui/`
+- Feature-specific components → `src/features/<feature>/components/`
+- Pure data utilities → `src/features/<feature>/utils/`
+- Do not promote a component to shared until there is a real second use case
+
+**Components**
+
+- Prefer server components by default; use `'use client'` only when
+  interactivity is required
+- Keep components small and single-purpose; avoid deeply nested JSX
+- Extract complex logic out of render blocks into utilities or memoized values
+
+**Naming**
+
+- React component: `PascalCase` matching filename
+- TanStack Query hook: `useGet…`, `usePut…`
+- BFF route handler: `GET`, `POST` inside `/api/…/route.ts`
+- Zod schema: `…Schema` suffix; derived type: matching PascalCase without suffix
+- Utility function: descriptive verb phrase, e.g. `buildSessionSegments`
+- Always follow existing patterns before introducing a new variation
+
+**TypeScript**
+
+- Prefer explicit types when clarity matters; use inference when the type is
+  obvious
+- Avoid `any`, broad unions, and excessive type casting
+- Use narrow types (`'PENDING' | 'COMPLETED'`) over broad ones (`string`)

--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -1,0 +1,115 @@
+# VectorVerify
+
+VectorVerify is the web-based review, annotation, and monitoring platform for
+the VectorCam mosquito surveillance ecosystem. It transforms raw field data
+collected by VHTs into validated, certified surveillance intelligence ready for
+national health systems.
+
+## Language
+
+### Roles
+
+**VHT (Village Health Team)**: A field data collector who captures mosquito
+specimens and household survey data using the VectorCam mobile app. VHTs do not
+access VectorVerify directly. _Avoid_: Collector, field worker, field team
+
+**VCO (Vector Control Officer)**: An authorized expert (Access Level 3) who
+performs both the Annotation and Review workflows in VectorVerify. _Avoid_:
+Expert reviewer, annotator, program editor, supervisor
+
+### Workflows
+
+**Annotation**: A task-based workflow in which a VCO labels mosquito specimens
+(species, sex, abdomen status) to evaluate and improve ML model performance.
+Distinct from Review. _Avoid_: Expert review, labeling
+
+**Review**: A site-and-collection-cycle-scoped workflow in which a VCO validates
+surveillance data quality and certifies it for submission to national health
+systems. Distinct from Annotation. _Avoid_: Data review (ambiguous), QA
+
+### Core Entities
+
+**Program**: The top-level organizational unit. All sites, users, sessions, and
+forms belong to a program.
+
+**Site**: A node in the program's location hierarchy (e.g. district → parish →
+village). Sites form a tree via a self-referencing parent. _Avoid_: Location,
+household
+
+**Sentinel Site**: A site at the leaf of the location hierarchy where mosquito
+collection actually occurs (`has_data = true`). The term is used in the web app
+UI; the API calls these "leaf sites". _Avoid_: Leaf site (in UI-facing language)
+
+**Collection Schedule**: The program-level pattern that governs how Collection
+Cycles are generated. One active schedule per program at any time. Two modes:
+`RECURRING` (auto-generates cycles at a fixed interval, e.g. every 2 months)
+and `MANUAL` (cycles are created explicitly by an authorized user). Changing a
+schedule ends the current one and starts a new one. _Avoid_: Cadence, frequency
+setting
+
+**Collection Cycle**: A concrete time window (startDate → endDate) generated
+from a Collection Schedule, used to group Sessions for Review and reporting.
+Replaces the default calendar-month grouping. Cycles are program-scoped — all
+sites in a program share the same schedule. A session whose collection date
+falls outside any cycle window can be manually re-assigned to an adjacent cycle
+by a VCO during Review (the exception case). _Avoid_: Reporting period, month
+(when a custom cycle is in use)
+
+**Session**: A single field data collection event at a site, conducted by a VHT
+using the VectorCam mobile app. Only sessions of type `SURVEILLANCE` enter the
+Review workflow. _Avoid_: Submission, collection event
+
+**Session State**: The lifecycle stage of a Session. In order: `NEEDS_REVIEW` →
+`IN_REVIEW` → `CERTIFIED` → `SUBMITTED`. `NOT_APPLICABLE` is set on
+non-surveillance sessions (type `CALIBRATION`, `PRACTICE`, `DATA_COLLECTION`)
+that never enter the Review workflow.
+
+**Certification**: The act of a VCO marking a reviewed session as complete and
+ready for DHIS2 submission. Sets state to `CERTIFIED`. _Avoid_: Approval,
+sign-off
+
+**Submission**: The act of a user manually triggering the DHIS2 sync for
+certified sessions. Sets state to `SUBMITTED`. Distinct from Certification —
+Certification is a review decision; Submission is the export action. _Avoid_:
+Export, sync
+
+**Specimen**: A single captured mosquito associated with a session. _Avoid_:
+Sample, mosquito
+
+**Annotation Task**: A curated set of specimens assigned to a VCO for
+Annotation. _Avoid_: Task (alone, ambiguous)
+
+**Morph Classification**: The label a VCO assigns to a specimen based on
+physical morphology (e.g. wing venation, structural features). One of two
+classification types recorded per annotation. _Avoid_: Morphological
+
+**Visual Classification**: The label a VCO assigns based on direct visual
+inspection of the specimen image. One of two classification types recorded per
+annotation. _Avoid_: Image-based
+
+## Relationships
+
+- A **Program** contains many **Sites**
+- A **Site** hosts many **Sessions**
+- A **Session** contains many **Specimens**
+- A **Session** belongs to one **Collection Cycle**
+- A **Specimen** belongs to exactly one **Session**
+- An **Annotation Task** contains many **Specimens** drawn from across sessions
+- A **VCO** performs **Annotation** (via Annotation Tasks) and **Review** (via
+  the Review workflow)
+- A **VHT** creates **Sessions** and **Specimens** via the VectorCam mobile app
+
+## Flagged ambiguities
+
+- "Sentinel site" (web app doc language) and "leaf site" (API code language)
+  refer to the same concept — a site with `has_data = true`. Use "Sentinel Site"
+  in UI-facing contexts.
+- "Household" is informal shorthand for a Session and its associated
+  Surveillance Form — there is no Household entity in the data model.
+
+- "Expert Reviewer" was used in user stories to mean **VCO** — resolved: use VCO
+- "Annotation" and "Review" are two distinct workflows, not two distinct roles —
+  both performed by a **VCO**
+- The Review workflow was described as "site-and-month-scoped" — updated to
+  "site-and-collection-cycle-scoped" now that Collection Cycles can replace
+  calendar months

--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -42,8 +42,8 @@ UI; the API calls these "leaf sites". _Avoid_: Leaf site (in UI-facing language)
 
 **Collection Schedule**: The program-level pattern that governs how Collection
 Cycles are generated. One active schedule per program at any time. Two modes:
-`RECURRING` (auto-generates cycles at a fixed interval, e.g. every 2 months)
-and `MANUAL` (cycles are created explicitly by an authorized user). Changing a
+`RECURRING` (auto-generates cycles at a fixed interval, e.g. every 2 months) and
+`MANUAL` (cycles are created explicitly by an authorized user). Changing a
 schedule ends the current one and starts a new one. _Avoid_: Cadence, frequency
 setting
 

--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -1,0 +1,546 @@
+# VectorVerify Architecture
+
+_Created: Mar 8, 2026 | Last Updated: Mar 8, 2026_
+
+## Why This Document Matters
+
+This is the core technical resource for understanding how the VectorVerify web
+application is built and structured. Every developer, intern, or contributor
+should read this carefully before attempting feature work.
+
+This guide explains:
+
+- Our overall architectural philosophy
+- Folder and module layout
+- How the app is split across server-side and client-side code
+- How data flows through the app
+- How shared API functions work
+- How the Result-based structure is used across network calls
+- How the BFF (Backend-for-Frontend) layer works
+- How TanStack Query is used for client-side data orchestration
+- How Zod is used for validation and type inference
+- How `proxy.ts` protects routes
+- How component modularity is handled across shared and feature-specific UI
+- Where to make changes depending on what you are building
+- Key files and how they interact
+- Performance and implementation considerations
+
+VectorVerify is built with Next.js, React, TypeScript, TanStack Query, and Zod.
+The project uses strict TypeScript settings, path aliases, and lint-enforced
+module boundaries to keep the architecture disciplined and scalable.
+
+---
+
+## Architectural Philosophy: Modular, Boundary-Driven, and Server-Aware
+
+VectorVerify is designed to be modular, predictable, and maintainable as the
+system evolves. The architecture emphasizes clear boundaries between different
+parts of the application so that developers can reason about behavior locally
+without needing to understand the entire codebase at once.
+
+> **At its core:** dependencies flow toward shared logic — UI and feature layers
+> can depend on infrastructure and utilities, but shared modules should never
+> depend on UI components or feature implementations.
+
+### Core Principles
+
+- **Separation of concerns** — UI rendering, backend communication, validation,
+  and infrastructure logic are implemented in separate modules that interact
+  through clearly defined interfaces.
+- **Client–server boundary enforcement** — Client-side code handles UI
+  interaction and state management. Server-side code handles secure backend
+  communication and authentication. These responsibilities are deliberately kept
+  separate.
+- **Feature modularity** — Workflows are organized into feature-scoped modules
+  that encapsulate their own components, API functions, and validation logic.
+- **BFF mediation** — Client interactions with backend services are mediated
+  through a dedicated server-side layer that centralizes backend communication,
+  authentication handling, and request orchestration.
+- **Composable component design** — Interface elements are built as small,
+  reusable components that can be composed into larger feature-level views.
+- **Testability** — Modules are structured with clear boundaries and minimal
+  side effects so that core logic, utilities, and feature behavior can be tested
+  in isolation.
+
+---
+
+## Folder Structure
+
+| Folder            | Purpose                                                                                                    |
+| ----------------- | ---------------------------------------------------------------------------------------------------------- |
+| `src/app/`        | App Router pages, layouts, route groups, and BFF route handlers                                            |
+| `src/api/`        | Shared backend resource access modules, query hooks, query keys, and validation schemas                    |
+| `src/components/` | Shared reusable UI primitives, layout components, and providers                                            |
+| `src/features/`   | Feature-scoped modules such as auth, annotation, and review workflows                                      |
+| `src/lib/`        | Shared infrastructure such as auth-session helpers, networking utilities, result types, and reusable hooks |
+| `src/utils/`      | Small generic helpers used across the app                                                                  |
+| `src/proxy.ts`    | Route protection and redirect logic at the application boundary                                            |
+
+---
+
+## Architecture Layers
+
+### The Routing Layer
+
+Defines application entry points, layouts, route groups, and server-side route
+handlers. Built using the Next.js App Router.
+
+**Common folders:** `src/app/`, `src/app/api/`
+
+**Examples:**
+
+- `src/app/layout.tsx`
+- `src/app/(dashboard)/annotate/page.tsx`
+- `src/app/api/annotations/task/route.ts`
+
+---
+
+### The UI Layer
+
+Displays UI, reacts to user interaction, and composes reusable interface
+components. Built using React, the Next.js component model, and the shadcn/ui
+component library.
+
+Components in this layer should focus on **presentation and composition** — not
+complex business logic or backend communication. Interface elements should be
+small, composable, and reusable.
+
+**Common folders:** `src/components/`, `src/components/ui/`,
+`src/features/<feature>/components/`
+
+**Examples:**
+
+- `login-form.tsx`
+- `annotation-task-card.tsx`
+- `annotation-workspace.tsx`
+- `src/components/ui/button.tsx`
+
+Shared UI primitives from `src/components/ui/` are typically based on shadcn/ui
+components, while feature-level components under `src/features/.../components/`
+compose these primitives into complete application views.
+
+---
+
+### The Backend Resource Layer
+
+Provides shared access to backend resources used throughout the application.
+Centralizes access to backend resources in reusable modules rather than allowing
+each feature to implement its own network logic.
+
+Each resource module contains the functions, validation schemas, and hooks
+required to retrieve or modify that resource.
+
+**Common folders:** `src/api/`, `src/api/<resource>/`,
+`src/api/<resource>/hooks/`, `src/api/<resource>/validation/`
+
+**Examples of resources:** `annotation-task`, `specimen`, `user`, `session`
+
+**Examples of files:**
+
+- `src/api/annotation-task/get-annotation-tasks.ts`
+- `src/api/annotation-task/hooks/use-get-annotation-tasks.ts`
+- `src/api/user/get-user-profile.ts`
+- `src/api/specimen/validation/get-specimens-schema.ts`
+
+---
+
+### The Infrastructure Layer
+
+Provides shared low-level utilities and cross-cutting functionality. Modules
+here are generic, reusable, and independent of feature-specific workflows.
+Features and API modules can depend on infrastructure utilities, but
+**infrastructure modules should not depend on feature code**.
+
+**Common folders:** `src/lib/`, `src/utils/`
+
+**Examples:**
+
+- `safe-api-call.ts`
+- `with-auth-session.ts`
+- `construct-query-string.ts`
+- `result.ts`
+- `network-error.ts`
+
+---
+
+### The Feature Layer
+
+Implements application workflows and organizes feature-specific behavior. Each
+feature represents a cohesive unit of functionality (e.g. authentication,
+annotation tasks, review interfaces) and is self-contained.
+
+```
+/feature/
+├── components/   ← Feature-specific UI and interaction logic
+├── api/          ← Feature-specific API functions when needed
+├── lib/          ← Feature-specific helpers or shared logic
+└── validation/   ← Zod schemas and feature-specific data contracts
+```
+
+---
+
+## Core Principles
+
+### Server-Client Execution Boundaries
+
+The application runs in two separate execution environments with different
+capabilities, responsibilities, and security constraints.
+
+**Server-side responsibilities:**
+
+- Communicating with backend services
+- Performing upstream API requests
+- Handling authentication and session context
+- Mediating requests coming from the browser
+- Coordinating data retrieval for application pages
+- Enforcing security boundaries between the frontend and backend
+
+**Client-side responsibilities:**
+
+- Rendering the user interface
+- Handling user input and interaction
+- Managing UI state
+- Triggering requests for data when needed
+- Updating the interface in response to data changes
+
+Client-side code should **not** contain logic that requires access to secure
+backend systems or authentication credentials.
+
+---
+
+### Server Functions for Backend Communication
+
+All direct communication with backend APIs is performed through server-side API
+functions. These functions are responsible for performing upstream HTTP
+requests, attaching authentication context, handling network failures, and
+returning responses in a consistent structure.
+
+```ts
+import {
+    getAnnotationTasksQueryParamsSchema,
+    getAnnotationTasksResponseSchema,
+    type GetAnnotationTasksQueryParams,
+    type GetAnnotationTasksResponseBody,
+} from '@/api/annotation-task/validation/get-annotation-tasks-schema';
+import { constructQueryString } from '@/lib/network/construct-query-string';
+import { safeApiCall } from '@/lib/network/safe-api-call';
+
+export async function getAnnotationTasks(
+    accessToken: string,
+    queryParams?: GetAnnotationTasksQueryParams,
+) {
+    const queryString = constructQueryString<GetAnnotationTasksQueryParams>(
+        queryParams,
+        getAnnotationTasksQueryParamsSchema,
+    );
+
+    return safeApiCall<GetAnnotationTasksResponseBody>(
+        `/annotations/task${queryString}`,
+        {
+            method: 'GET',
+            headers: {
+                Authorization: `Bearer ${accessToken}`,
+            },
+        },
+        getAnnotationTasksResponseSchema,
+    );
+}
+```
+
+---
+
+### The BFF (Backend-for-Frontend) Layer
+
+Client-side code cannot communicate directly with protected backend APIs.
+Instead, it interacts through a BFF layer implemented using Next.js route
+handlers. The BFF receives requests from client-side code, validates inputs,
+retrieves authentication context, calls the appropriate server function, and
+returns a standardized response.
+
+```ts
+import { getAnnotationTasks } from '@/api/annotation-task/get-annotation-tasks';
+import {
+    getAnnotationTasksQueryParamsSchema,
+    type GetAnnotationTasksResponseBody,
+} from '@/api/annotation-task/validation/get-annotation-tasks-schema';
+import { err } from '@/lib/result/result';
+import { NextResponse } from 'next/server';
+import { withAuthSession } from '@/lib/auth-session/with-auth-session';
+
+export async function GET(request: Request) {
+    const url = new URL(request.url);
+    const queryParams = Object.fromEntries(url.searchParams.entries());
+
+    const parsedQueryParams =
+        getAnnotationTasksQueryParamsSchema.safeParse(queryParams);
+    if (!parsedQueryParams.success) {
+        return NextResponse.json(
+            err({
+                kind: 'client',
+                status: 400,
+                message: 'Invalid query parameters',
+            }),
+            { status: 400 },
+        );
+    }
+
+    const result = await withAuthSession<GetAnnotationTasksResponseBody>(
+        accessToken => getAnnotationTasks(accessToken, parsedQueryParams.data),
+    );
+
+    return NextResponse.json(result, {
+        status: result.ok ? 200 : (result.error.status ?? 400),
+    });
+}
+```
+
+---
+
+### Client Data Fetching with TanStack Query
+
+Client-side data fetching uses TanStack Query. The typical flow:
+
+1. Client components trigger data requests
+2. TanStack Query manages the request lifecycle
+3. The BFF layer (`/app/api/...`) handles secure server communication
+4. Server functions perform the upstream backend call
+
+```ts
+import {
+    getAnnotationTasksQueryParamsSchema,
+    type GetAnnotationTasksQueryParams,
+    type GetAnnotationTasksSuccessPayload,
+} from '@/api/annotation-task/validation/get-annotation-tasks-schema';
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { annotationTaskKeys } from '@/api/annotation-task/annotation-task-keys';
+import type { NetworkError } from '@/lib/network/network-error';
+import { constructQueryString } from '@/lib/network/construct-query-string';
+import type { Result } from '@/lib/result/result';
+
+type GetAnnotationTasksQueryResult = Result<
+    GetAnnotationTasksSuccessPayload,
+    NetworkError
+>;
+type GetAnnotationTasksQueryOptions = Omit<
+    UseQueryOptions<GetAnnotationTasksQueryResult, NetworkError>,
+    'queryKey' | 'queryFn'
+>;
+
+async function fetchAnnotationTasks(
+    queryParams?: GetAnnotationTasksQueryParams,
+): Promise<GetAnnotationTasksQueryResult> {
+    const queryString = constructQueryString<GetAnnotationTasksQueryParams>(
+        queryParams,
+        getAnnotationTasksQueryParamsSchema,
+    );
+
+    const response = await fetch(`/api/annotations/task${queryString}`, {
+        method: 'GET',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+    });
+
+    return response.json();
+}
+
+export function useGetAnnotationTasks(
+    queryParams?: GetAnnotationTasksQueryParams,
+    options?: GetAnnotationTasksQueryOptions,
+) {
+    return useQuery({
+        queryKey: annotationTaskKeys.annotationTasks(queryParams),
+        queryFn: () => fetchAnnotationTasks(queryParams),
+        ...options,
+    });
+}
+```
+
+---
+
+### Query Keys
+
+Query keys are defined in centralized modules so they can be reused consistently
+across the application.
+
+```ts
+import type { GetAnnotationTasksQueryParams } from '@/api/annotation-task/validation/get-annotation-tasks-schema';
+
+export const annotationTaskKeys = {
+    root: ['annotation-tasks'] as const,
+    annotationTasks: (queryParams?: GetAnnotationTasksQueryParams) =>
+        ['annotation-tasks', queryParams] as const,
+};
+```
+
+---
+
+### Zod Schemas and Validation Contracts
+
+Zod is used for runtime validation and TypeScript type inference. All external
+data entering the application must be validated.
+
+**Query parameter validation:**
+
+```ts
+export const getAnnotationTasksQueryParamsSchema = z.object({
+    startDate: z.string().optional(),
+    endDate: z.string().optional(),
+    title: z.string().optional(),
+    status: annotationTaskStatusSchema.optional(),
+    page: z.coerce.number().optional(),
+    limit: z.coerce.number().optional(),
+});
+
+export type GetAnnotationTasksQueryParams = z.infer<
+    typeof getAnnotationTasksQueryParamsSchema
+>;
+```
+
+**Request body validation:**
+
+```ts
+export const putAnnotationByIdRequestSchema = z.object({
+    morphSpecies: z.string().optional(),
+    morphSex: z.string().optional(),
+    morphAbdomenStatus: z.string().optional(),
+    visualSpecies: z.string().optional(),
+    visualSex: z.string().optional(),
+    visualAbdomenStatus: z.string().optional(),
+    notes: z.string().optional(),
+    status: annotationStatusSchema,
+});
+
+export type PutAnnotationByIdRequestBody = z.infer<
+    typeof putAnnotationByIdRequestSchema
+>;
+```
+
+**Response body validation:**
+
+```ts
+export const getAnnotationTasksResponseSchema = z.object({
+    tasks: z.array(annotationTaskSchema),
+    total: z.number(),
+    limit: z.number(),
+    offset: z.number(),
+    hasMore: z.boolean(),
+});
+
+export type GetAnnotationTasksResponseBody = z.infer<
+    typeof getAnnotationTasksResponseSchema
+>;
+export type GetAnnotationTasksSuccessPayload = GetAnnotationTasksResponseBody;
+```
+
+**Feature-level form validation:**
+
+```ts
+export const signupFormSchema = z
+    .object({
+        email: z.email('Enter a valid email'),
+        password: z
+            .string()
+            .min(1, 'Password is required')
+            .max(128, 'Password is too long'),
+        confirmPassword: z.string().min(1, 'Confirm Password is required'),
+    })
+    .refine(data => data.password === data.confirmPassword, {
+        message: 'Passwords must match',
+        path: ['confirmPassword'],
+    });
+
+export type SignupFormInput = z.infer<typeof signupFormSchema>;
+```
+
+**Shared resource shapes:**
+
+```ts
+export const annotationTaskSchema = z.object({
+    id: z.number(),
+    annotatorId: z.number().optional(),
+    title: z.string(),
+    description: z.string(),
+    status: annotationTaskStatusSchema,
+    annotationCounts: z
+        .object({
+            total: z.number(),
+            pending: z.number(),
+            annotated: z.number(),
+            flagged: z.number(),
+        })
+        .optional(),
+    createdAt: z.number(),
+    updatedAt: z.number(),
+    annotator: userProfileSchema.optional(),
+});
+```
+
+---
+
+### Server Actions
+
+Server Actions allow certain operations to run directly on the server. They are
+defined using the `'use server'` directive and are typically used for
+authentication flows, cookie/session updates, server-side redirects, and simple
+mutations.
+
+```ts
+'use server';
+
+import { clearAuthCookies } from '@/lib/auth-session/cookies';
+import { redirect } from 'next/navigation';
+
+export async function logout() {
+    await clearAuthCookies();
+    redirect('/login');
+}
+```
+
+---
+
+### Request Protection with `proxy.ts`
+
+`proxy.ts` enforces authentication rules at the edge before a request reaches
+application routes. Its responsibilities:
+
+- Checking whether authentication cookies are present
+- Redirecting unauthenticated users to the login page
+- Preventing authenticated users from accessing public authentication routes
+- Ensuring protected routes remain secure
+
+---
+
+### Component Abstraction and Modularity
+
+The application distinguishes between:
+
+- **Shared components** — live in `src/components/` and provide reusable
+  building blocks (layout elements, buttons, cards, tables, input controls)
+- **Feature-specific components** — live in `src/features/` and compose shared
+  building blocks into complete screens and workflows
+
+**Server Components:**
+
+- Render on the server
+- Can fetch data directly from server functions
+- Do not include browser-side interactivity
+- Reduce client bundle size
+
+**Client Components:**
+
+- Run in the browser
+- Handle user interactions and dynamic UI behavior
+- Can use hooks (`useState`, `useEffect`, TanStack Query)
+- Declared using the `'use client'` directive
+
+---
+
+## Best Practices
+
+- Favor simple, predictable patterns over clever abstractions
+- Keep features self-contained so related logic stays easy to locate and modify
+- Reuse existing infrastructure and utilities before introducing new patterns
+- Make data flow explicit and easy to trace from UI interaction to backend
+  response
+- Prioritize readability and maintainability so new contributors can quickly
+  understand the system

--- a/.claude/docs/best-practices.md
+++ b/.claude/docs/best-practices.md
@@ -1,0 +1,207 @@
+# VectorVerify Best Practices
+
+_Created: Mar 8, 2026 | Last Updated: Mar 8, 2026_
+
+## Purpose
+
+Writing code is not just about making something work — it's about making it
+clear, maintainable, and consistent with the rest of the system.
+
+This document outlines the standards and conventions expected when working on
+the VectorVerify web application.
+
+---
+
+## General Clean Coding Principles
+
+| Principle                               | Description                                                                                    |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Small, single-purpose functions         | Functions should do one thing and do it well. If it starts doing multiple things, split it up. |
+| Clear naming > clever naming            | Names should describe intent and behavior. Avoid abbreviations that make code harder to read.  |
+| Avoid duplication                       | If the same logic appears multiple times, extract it into a shared utility or module.          |
+| No magic numbers                        | Extract numbers or hardcoded strings to constants (or string resources if UI-related).         |
+| Minimize side effects                   | Functions should not unexpectedly change global state.                                         |
+| Leave the code better than you found it | If something's unclear or messy — improve it.                                                  |
+
+---
+
+## TypeScript Best Practices
+
+### Do
+
+```ts
+// Prefer explicit types when clarity matters
+type AnnotationTask = { id: number; status: 'PENDING' | 'COMPLETED' };
+
+// Use type inference when obvious
+const count = tasks.length;
+
+// Prefer const over let
+const tasks = [];
+
+// Use type-safe contracts derived from Zod schemas
+export type GetAnnotationTasksResponse = z.infer<
+    typeof getAnnotationTasksResponseSchema
+>;
+
+// Use narrow types instead of broad ones
+status: 'PENDING' | 'COMPLETED';
+```
+
+### Avoid
+
+```ts
+// any
+function process(data: any) {}
+
+// Unclear union types
+string | number | boolean | object;
+
+// Excessive type casting
+const value = something as unknown as MyType;
+
+// Broad types when narrow ones are available
+status: string;
+```
+
+---
+
+## React Component Best Practices
+
+### Do
+
+- Keep components small and focused
+- Break complex pages into smaller reusable components
+- Use server components whenever possible
+- Use client components only when interactivity is required
+- Prefer declarative rendering:
+
+```tsx
+{
+    tasks.map(task => <TaskCard key={task.id} task={task} />);
+}
+```
+
+- Keep components readable and predictable
+
+### Avoid
+
+- Large monolithic page files
+- Deeply nested JSX
+- Embedding complex logic directly inside render blocks:
+
+```tsx
+// Don't do this
+{tasks.filter(...).map(...).sort(...)}
+```
+
+---
+
+## Data Fetching and Server Interaction
+
+- Follow the established architecture patterns
+- Use the custom `Result<T, E>` type defined in `lib/result` to wrap
+  success/failure and keep flow safe
+- Avoid `try/catch` in the UI layer — errors should be caught and logged
+  upstream
+- For unrecoverable issues, show a user-friendly message via a UI state update
+  or event
+
+### Client Components
+
+- Client components should **never** call backend APIs directly
+- All data fetching should happen through TanStack Query and BFF endpoints
+
+### Server Components
+
+- Server components can fetch data using server functions
+- They should not contain client-side hooks (`useState`, `useEffect`,
+  `useQuery`)
+
+---
+
+## Zod Validation Best Practices
+
+All external data entering the application must be validated. Use Zod schemas
+for:
+
+- API request bodies
+- API responses
+- Query parameters
+- Form validation
+
+---
+
+## Component Modularity and Styling
+
+- Favor composition over duplication
+- Shared UI primitives live in `src/components/`. Feature-specific UI lives in
+  `src/features/<feature>/components/`
+- Avoid copying UI logic between features — extract reusable components instead
+- Prefer utility classes rather than custom CSS. Avoid large, custom stylesheets
+- Prefer using the styling classes already defined in `globals.css`
+
+---
+
+## Naming Conventions
+
+| Type                | Example                                                           |
+| ------------------- | ----------------------------------------------------------------- |
+| React Component     | `AnnotationTaskCard`, `LoginForm`, `DashboardPageClient`          |
+| Page Component      | `AnnotationTasksPage`                                             |
+| Server Function     | `getAnnotationTasks`, `putAnnotationById`                         |
+| BFF Route Handler   | `GET`, `POST` inside `/api/…/route.ts`                            |
+| TanStack Query Hook | `useGetAnnotationTasks`, `usePutAnnotationById`                   |
+| Query Keys          | `annotationTaskKeys`, `annotationKeys.root`, `userKeys.profile()` |
+| Zod Schema          | `getAnnotationTasksResponseBodySchema`, `loginFormSchema`         |
+| Type from Schema    | `GetAnnotationTasksResponseBody`, `LoginFormInput`                |
+| Utility Function    | `constructQueryString`, `safeApiCall`                             |
+| Feature Folder      | `annotation-task`, `auth`                                         |
+
+Always follow the existing naming structure before introducing your own
+variation.
+
+---
+
+## Performance Tips
+
+- Prefer Server Components by default. Only introduce Client Components when
+  browser-side interactivity is required
+- Use TanStack Query caching effectively. Reuse query keys and avoid unnecessary
+  refetching
+- Avoid expensive computations inside render logic. Extract complex operations
+  into utilities or memoized values
+- Use pagination or lazy rendering for large datasets instead of rendering large
+  lists all at once
+
+---
+
+## How to Leave the Code Better
+
+Engineering responsibility includes improving the codebase over time:
+
+- Fix naming inconsistencies
+- Improve unclear logic or split large functions
+- Add documentation to confusing blocks
+- Reduce duplication (e.g., repeated validation logic)
+- Improve type safety
+- Add TODOs where work is still needed — and file a ticket in JIRA
+
+If you come across unclear or messy code, don't ignore it — clean it up or
+document it for the next person.
+
+---
+
+## Pre-PR Checklist
+
+Before submitting a pull request or starting a new feature, make sure:
+
+- [ ] The feature follows the existing folder and feature structure
+- [ ] Server and client responsibilities remain clearly separated
+- [ ] Data fetching follows the server function → BFF → TanStack Query pattern
+- [ ] Zod schemas define and validate all external data contracts
+- [ ] Components are modular and reusable, not large monolithic pages
+- [ ] Query keys and hooks follow the existing naming patterns
+- [ ] No business logic or API calls are embedded directly in UI components
+- [ ] Naming conventions match the existing codebase patterns
+- [ ] The code is readable, typed, and consistent with existing architecture

--- a/.claude/docs/feature-scope-gap.md
+++ b/.claude/docs/feature-scope-gap.md
@@ -1,0 +1,147 @@
+## 1) Currently Implemented
+
+### Access and Security
+
+- User authentication is in place.
+- Role-based access controls are in place for key modules.
+
+### Annotation
+
+- Annotation tasks list is available with status/date filtering.
+- Annotation workspace is available and usable.
+- Annotators can submit core labels and notes/artifact flags.
+
+### Operations (Site Monitoring)
+
+- Sites overview tab is available.
+- District and date-range filtering are available.
+- Site activity and review-state indicators are available.
+
+### Review Workflow (Step 1 Only)
+
+- Site and month selection is available.
+- Users can see site-level review state and session counts.
+
+## 2) Needs To Be Implemented / In Progress
+
+### Review Workflow Completion
+
+- Step 2 (surveillance questions review) is not complete as an end-to-end
+  workflow.
+- Step 3 (specimen review for site-month validation) is not implemented.
+- Step 4 (site monthly certification) is not implemented.
+- There is a navigation gap after Step 1, so the full review journey is not yet
+  complete in the UI.
+
+### Dashboard (Home page)
+
+- Dashboard shell exists, but expected operational summary content is still
+  missing.
+- Missing: summary metrics, pending review highlights, flagged record
+  visibility, trend views, and action shortcuts.
+
+### Operations Analytics Expansion
+
+- Metrics tab is scaffolded but not yet fully populated with production-grade
+  live analytics.
+- Model Accuracy tab is currently prototype-level (layout present, live
+  integration still needed).
+- VHT Compliance tab is not yet implemented.
+
+### Delphi Method Integration
+
+Status: Not implemented
+
+Required outcome:
+
+- Add a formal Delphi-method workflow for expert consensus where disagreements
+  or uncertain records require structured multi-reviewer rounds and convergence
+  tracking.
+
+What this should enable:
+
+- Controlled consensus review rounds.
+- Transparent disagreement tracking.
+- Documented final consensus decision before certification where required.
+
+### National Reporting Export (DHIS2)
+
+Status: Not currently implemented for DHIS2 reporting flow
+
+Context:
+
+- Requirement states validated data should be exportable to national reporting
+  platforms such as DHIS2.
+- Current direct reporting flow to DHIS2 is not live.
+- Known constraint: current submission process can take approximately 18
+  minutes, which is a blocker for practical operations.
+
+Needed next step:
+
+- Implement a production-ready DHIS2 export/reporting approach that handles
+  long-running submissions reliably (for example, asynchronous job-based
+  processing with status tracking and retries).
+
+## 3) Readiness Summary
+
+What is ready now:
+
+- Secure access control
+- Annotation operations
+- Site-level operations monitoring
+- Initial review entry step
+
+What is not yet ready for full program operations:
+
+- Complete monthly review-to-certification workflow
+- Production-grade analytics and compliance reporting
+- DHIS2 reporting integration
+- Delphi consensus review capability
+
+## 4) Priority Order (Stakeholder-Focused)
+
+1. Complete review workflow steps 2-4, including certification.
+2. Introduce Delphi-method consensus workflow for disputed/uncertain records.
+3. Deliver DHIS2-ready export/reporting with long-running job handling.
+4. Complete Operations analytics and add VHT compliance reporting.
+5. Upgrade Dashboard to a true program command center.
+
+---
+
+## Leadership Snapshot (One-Page View)
+
+### RAG Status
+
+| Area                                     | Status    | Leadership Summary                                                                     |
+| ---------------------------------------- | --------- | -------------------------------------------------------------------------------------- |
+| Access and Security                      | Green     | Core authentication and role controls are functioning.                                 |
+| Annotation Workflow                      | Green     | Task-based annotation is usable and supports active operations.                        |
+| Operations: Sites Overview               | Green     | Site monitoring and review-state visibility are live.                                  |
+| Review Workflow End-to-End               | Red       | Only entry step is live; validation and certification steps are not complete.          |
+| Dashboard                                | Amber     | Basic shell exists, but key operational insights are still missing.                    |
+| Operations Analytics (Metrics/Model/VHT) | Amber/Red | Metrics is in progress, model accuracy is prototype-level, VHT tab is not implemented. |
+| Delphi Consensus Workflow                | Red       | Not implemented.                                                                       |
+| DHIS2 Reporting Integration              | Red       | Not live; current submission performance (about 18 minutes) is a known blocker.        |
+
+### Key Risks
+
+- End-to-end monthly review and certification is not yet executable in one
+  complete flow.
+- National reporting integration (DHIS2) is not currently production-ready.
+- Analytics are not yet complete enough for full management reporting.
+
+### Next 90-Day Outcome Focus
+
+1. Complete review workflow steps 2-4 and certification controls.
+2. Implement Delphi consensus process for disputed/uncertain records.
+3. Deliver asynchronous DHIS2 export pipeline with job status tracking and retry
+   handling.
+4. Finalize operations analytics and add VHT compliance reporting.
+5. Upgrade dashboard to operational command-center quality.
+
+### Executive Message
+
+"VectorVerify is strong in core platform foundations and annotation operations.
+The immediate priority is closing the review-to-certification and DHIS2
+reporting gaps so the platform can fully support end-to-end national
+surveillance workflows."

--- a/.claude/docs/form-api-usecases.md
+++ b/.claude/docs/form-api-usecases.md
@@ -1,0 +1,142 @@
+# CUSTOM FORM API USE CASES
+
+## USE CASE 1: Admin Updates Draft Form and Adds Questions
+
+Step 1: Get the current draft form Endpoint: GET
+/programs/{program_id}/forms/draft Auth: Superadmin Input: program_id in path
+Output: { id: number, programId: number, name: string, version: "" (empty string
+means draft), createdAt: timestamp, updatedAt: timestamp, questions: [array of
+questions with nested subQuestions] }
+
+Step 2: Update form name (optional) Endpoint: PUT /programs/{program_id}/forms
+Auth: Superadmin Input: Path: program_id Body: { name: "Updated Form Name" }
+Output: { message: "Form updated successfully", form: { id, programId, name,
+version: "", createdAt, updatedAt } }
+
+Step 3: Add a new question Endpoint: POST /programs/{program_id}/forms/questions
+Auth: Superadmin Input: Path: program_id Body: { parentId: null (or question_id
+for nested question), label: "What is the patient age?", type: "number",
+required: true, options: null (or ["option1", "option2"] for select/radio),
+order: 1 } Output: { message: "Question created successfully", question: { id:
+number, formId: number, parentId: null or number, label: string, type: string,
+required: boolean, options: array or null, order: number, createdAt: timestamp,
+updatedAt: timestamp } }
+
+Step 4: Update an existing question Endpoint: PUT
+/programs/{program_id}/forms/questions/{question_id} Auth: Superadmin Input:
+Path: program_id, question_id Body: { label: "Updated question text", required:
+false, order: 2 } Output: { message: "Question updated successfully", question:
+{ id, formId, parentId, label, type, required, options, order, createdAt,
+updatedAt } }
+
+Step 5: Delete a question Endpoint: DELETE
+/programs/{program_id}/forms/questions/{question_id} Auth: Superadmin Input:
+program_id, question_id in path Output: { message: "Question deleted
+successfully" }
+
+## USE CASE 2: Admin Publishes Form
+
+Step 1: Publish the draft form with a version number Endpoint: POST
+/programs/{program_id}/forms/publish Auth: Superadmin Input: Path: program_id
+Body: { version: "v1.0" } Output: { message: "Form published successfully",
+form: { id: number (new form id), programId: number, name: string, version:
+"v1.0", createdAt: timestamp, updatedAt: timestamp } } Note: This creates a NEW
+form with the published version. The draft remains unchanged.
+
+Step 2: Set the published version as the program's current form Endpoint: PUT
+/programs/{program_id} Auth: Admin Input: Path: program_id Body: { formVersion:
+"v1.0" } Output: { message: "Program updated successfully", program: { id, name,
+country, formVersion: "v1.0", createdAt, updatedAt } }
+
+## USE CASE 3: Admin Checks Out Published Form to Draft
+
+Step 1: Checkout a published version to draft for editing Endpoint: POST
+/programs/{program_id}/forms/{version}/checkout Auth: Superadmin Input: Path:
+program_id, version (e.g., "v1.0") Body: (empty) Output: { message: "Draft
+updated from published form", form: { id: number (draft form id), programId:
+number, name: string, version: "" (draft), createdAt: timestamp, updatedAt:
+timestamp, questions: [array of cloned questions with nested subQuestions] } }
+Note: This loads the published version into the draft. Existing draft questions
+are replaced.
+
+## USE CASE 4: Developer Submits Form Answers for a Session
+
+Step 1: Get the current form for the program Endpoint: GET
+/programs/{program_id}/forms/current Auth: Any authenticated user Input:
+program_id in path Output: { id: number, programId: number, name: string,
+version: string (the current published version), createdAt: timestamp,
+updatedAt: timestamp, questions: [array of questions with nested subQuestions] }
+Note: Returns the form version set in program.formVersion, or latest published
+if null.
+
+Step 2: Submit answers for a session Endpoint: POST
+/sessions/{session_id}/forms/answers Auth: User with write access to session
+Input: Path: session_id Body: { answers: [ { questionId: number, value: any
+(string, number, array, object), dataType: "string" | "number" | "boolean" |
+"array" | "object" }, ... ] } Output: { message: "Form answers created
+successfully", answers: [ { id: number, sessionId: number, formId: number,
+questionId: number, value: any, dataType: string, submittedAt: timestamp,
+createdAt: timestamp, updatedAt: timestamp }, ... ] } Note: Uses the program's
+current published form. Draft forms cannot be used for answers.
+
+Step 3: Update existing answers Endpoint: PUT
+/sessions/{session_id}/forms/answers Auth: User with write access to session
+Input: Path: session_id Body: { answers: [ { questionId: number, value: any,
+dataType: string }, ... ] } Output: { message: "Form answers updated
+successfully", answers: [array of updated answer objects] }
+
+## USE CASE 5: Admin Gets Form Answers for a Session
+
+Step 1: Get answers for the current form version Endpoint: GET
+/sessions/{session_id}/forms/answers Auth: User with read access to session
+Input: Path: session_id Query: (none - uses current form) Output: { formId:
+number, formName: string, formVersion: string, programId: number, sessionId:
+number, answers: [ { id: number, questionId: number, parentId: null or number,
+label: string, type: string, required: boolean, options: array or null, value:
+any, dataType: string, submittedAt: timestamp, createdAt: timestamp, updatedAt:
+timestamp }, ... ] }
+
+Step 2: Get answers for a specific form version Endpoint: GET
+/sessions/{session_id}/forms/answers?version=v1.0 Auth: User with read access to
+session Input: Path: session_id Query: version=v1.0 Output: Same as Step 1, but
+for the specified version
+
+## USE CASE 6: Admin Exports Form Answers as CSV
+
+Step 1: Export all form answers Endpoint: GET /sessions/export/forms/csv Auth:
+Admin Input: Query parameters (all optional): startDate: ISO date string
+endDate: ISO date string programId: number programCountry: string version:
+string (specific form version) Output: CSV file with headers: Answer ID, Session
+ID, Session Frontend ID, Site ID, Site Name, Program ID, Program Name, Form ID,
+Form Name, Form Version, Question ID, Question Label, Question Type, Answer
+Value, Data Type, Submitted At
+
+Step 2: Export answers for specific version Endpoint: GET
+/sessions/export/forms/csv?version=v1.0&programId=5 Auth: Admin Input: Query:
+version=v1.0, programId=5 Output: CSV file filtered by version and program
+
+## USE CASE 7: Admin Views All Form Versions
+
+Step 1: List all forms for a program Endpoint: GET /programs/{program_id}/forms
+Auth: Superadmin Input: program_id in path Output: { forms: [ { id: number,
+programId: number, name: string, version: string ("" for draft, "v1.0" etc for
+published), createdAt: timestamp, updatedAt: timestamp }, ... ] }
+
+Step 2: Get a specific form version with questions Endpoint: GET
+/programs/{program_id}/forms/{version} Auth: Superadmin Input: Path: program_id,
+version (e.g., "v1.0" or "draft") Output: { id: number, programId: number, name:
+string, version: string, createdAt: timestamp, updatedAt: timestamp, questions:
+[array of questions with nested subQuestions] }
+
+## IMPORTANT NOTES
+
+1. Draft forms have version = "" (empty string)
+2. Published forms have version = "v1.0", "v2.0", etc (any non-empty string)
+3. Only draft forms can be modified (update name, add/edit/delete questions)
+4. Publishing creates a NEW form with a new ID and the specified version
+5. Checkout loads a published version into the draft (replaces draft content)
+6. Only published forms can be used for recording answers
+7. Program.formVersion points to the currently active form version
+8. If formVersion is null, the latest published form is used
+9. Draft forms cannot be deleted (one draft per program always exists)
+10. When getting answers without specifying version, uses program's current form

--- a/.claude/docs/geographical-summary.md
+++ b/.claude/docs/geographical-summary.md
@@ -1,0 +1,279 @@
+# Geographical Summary — Implementation Notes
+
+_Created: Apr 16, 2026_
+
+## Data Sources and Why
+
+### Specimens (`/api/specimens/count`)
+
+Village information — name, parish, sub-county, district — comes exclusively
+from the specimens count endpoint via `siteInfo`. The `siteInfo` field is
+populated via a `JOIN` on the `sites` table and is the only reliable source of
+village names associated with the user's program.
+
+Sessions (`/api/sessions/all`) do **not** carry village-level location
+information (`formatSessionResponse` in the backend never includes the `site`
+field), so they cannot be used as the primary data source for geographic
+grouping.
+
+### Sessions (`/api/sessions/all`)
+
+Sessions are fetched solely to calculate `sessionCount` and `lastCollectionDate`
+per village. These are joined to the specimen data via `siteId → villageName`
+mapping built during aggregation.
+
+---
+
+## Why Group By Village Name (Not `siteId`)
+
+**Lead dev direction:** a single village may have multiple sites (houses) within
+it. Grouping by `siteId` would produce one marker per house, which is too
+granular and clutters the map. Grouping by `villageName` aggregates all specimen
+counts and sessions for an entire village into one marker.
+
+The tradeoff: if two sites in different locations happen to share the same
+village name, their data merges. This is acceptable for district-level
+surveillance overview.
+
+---
+
+## Why There Is No GPS Positioning
+
+Session records include GPS coordinates, but these reflect **where the session
+was submitted** (the field worker's phone location at upload time), not the
+actual collection site. During development, GPS data for Ugandan sessions was
+observed to show Baltimore, India, and Philadelphia. GPS coordinates are
+therefore completely unusable for map positioning.
+
+All marker positioning is done via **Nominatim geocoding** using the village
+name and location hierarchy.
+
+---
+
+## Geocoding Architecture
+
+### Why Server-Side (`/api/geocode/route.ts`)
+
+Nominatim's usage policy requires:
+
+- A valid `User-Agent` header identifying the application
+- Maximum 1 request per second per IP
+
+Calling Nominatim directly from the browser causes:
+
+- CORS errors when Nominatim returns 429 (rate limited) without CORS headers on
+  the error response — Chrome/Firefox report this as "CORS Missing Allow Origin"
+  even though it is actually a rate limit response
+- Every user's browser hitting Nominatim independently, multiplying the rate
+  limit pressure
+
+The `/api/geocode` route proxies all Nominatim requests from the server,
+enforces a 1100ms minimum interval between outgoing requests, and caches results
+in memory for 30 days.
+
+### Fallback Hierarchy (Server-Side)
+
+The client sends one request per village with the raw location fields:
+`?village=&parish=&subCounty=&district=`. The server builds and tries the
+following query chain internally until one resolves:
+
+1. `{villageName}, {parish} Parish, {district} District, Uganda`
+2. `{villageName}, {district} District, Uganda`
+3. `{parish} Parish, {district} District, Uganda`
+4. `{subCounty}, {district} District, Uganda`
+5. `{district} District, Uganda`
+
+This means the client makes **one HTTP call per village** rather than up to
+five. The server handles all fallbacks and only returns when one resolves (or
+all fail).
+
+The final fallback (district only) ensures markers always appear somewhere on
+the map, even for villages with unusual names that Nominatim cannot resolve
+directly (e.g. `"Guluguru + Aiywala"`, `"Ofua Subcounty"`).
+
+### Client-Side Cache (`use-village-geocode.ts`)
+
+A module-level `Map<string, GeocodedPosition>` caches resolved positions by
+village name for the duration of the browser session. This avoids redundant
+calls to `/api/geocode` when the user changes the date range but the same
+villages are returned.
+
+---
+
+## Program Isolation
+
+The backend enforces program isolation via `siteAccess.userSites` populated in
+the JWT middleware — users only receive data for sites they have been granted
+access to. The `programId` query parameter on `GET /specimens/count` is
+**ignored by the backend entirely** (`QueryParams` in `getCount.ts` has no
+`programId` field). Sending `programId` on the request has no effect and it has
+been removed from the frontend query and Zod schema.
+
+---
+
+## CSS Imports and TypeScript
+
+`site-map.tsx` imports three CSS files directly:
+
+```ts
+import 'leaflet/dist/leaflet.css';
+import 'react-leaflet-cluster/dist/assets/MarkerCluster.css';
+import 'react-leaflet-cluster/dist/assets/MarkerCluster.Default.css';
+```
+
+These are Leaflet's own styles (map controls, tile layer chrome, cluster bubble
+rendering). Tailwind does not replace them — they are unrelated to the project's
+own styling. Without them, the map renders broken.
+
+TypeScript has no type information for `.css` files. Next.js ships declarations
+for `*.module.css` (CSS Modules) in `next-env.d.ts` but not for plain
+side-effect imports. `src/types/global.d.ts` adds `declare module '*.css'` to
+silence the `Cannot find module` error for these imports. `src/types/` is
+registered as a `shared` element in `eslint.config.mjs` so the boundaries plugin
+recognises it.
+
+---
+
+## Schema Fixes
+
+### `specimensCountSchema` — nullable species/sex/abdomenStatus
+
+The backend joins `specimen_images` via a `LEFT JOIN`. When a specimen has not
+yet had an image recorded, the join returns `null` for `species`, `sex`, and
+`abdomenStatus`. The frontend Zod schema originally had `z.string()` for these
+fields, causing response validation to silently fail (returning
+`{ ok: false, error: { kind: 'client' } }` with status 400) whenever the result
+set contained unclassified specimens.
+
+Fix: changed to `z.string().nullable()` on all three fields. The aggregation in
+`use-site-markers.ts` skips counts with null species when building the species
+breakdown.
+
+### `siteSchema` — nullable location fields
+
+The backend marks `district`, `subCounty`, `parish`, `villageName`,
+`healthCenter`, `name`, and `locationTypeId` as `nullable: true` in its Swagger
+schema. The frontend `siteSchema` previously used `.optional()` (which accepts
+`undefined` but not `null`), causing Zod validation failures when the backend
+explicitly returned `null` for these fields.
+
+Fix: changed all nullable location fields to `.nullable().optional()`.
+`locationHierarchy` uses `.optional().default({})` since it is always an object
+when present.
+
+---
+
+## Key Functions
+
+### `aggregateByVillage(data)` — `use-site-markers.ts`
+
+Groups specimen count entries by `siteInfo.villageName`. Builds two outputs:
+
+- `villageData` — a `Map<villageName, VillageData>` with accumulated specimen
+  and Anopheles counts plus species breakdowns
+- `siteIdToVillage` — a `Map<siteId, villageName>` used to join session data
+
+Sites without a `villageName` are skipped entirely.
+
+### `sessionStatsByVillage(sessions, siteIdToVillage)` — `use-site-markers.ts`
+
+Iterates sessions and uses `siteIdToVillage` to count sessions and find the most
+recent `collectionDate` per village.
+
+### `buildMarkers(villageData, sessionStats)` — `use-site-markers.ts`
+
+Combines the two maps into the final `VillageMarker[]` array. Species breakdown
+is sorted descending by count and capped at 5 entries for tooltip display.
+
+### `totalVillages` — `useSiteMarkers` return value
+
+Counts only markers with `sessionCount > 0`. Specimens data includes all sites
+in the user's program regardless of whether they have sessions in the selected
+date range (the backend pre-populates all accessible sites), so filtering by
+`sessionCount > 0` gives the number of villages that were actually visited.
+
+### `useVillageGeocode(markers)` — `use-village-geocode.ts`
+
+Runs a sequential geocoding loop (one village at a time) to avoid concurrently
+overloading the server-side rate limiter. Keyed by a stable string derived from
+sorted village IDs — the loop only restarts when the set of villages actually
+changes, not on every parent re-render.
+
+### `MapNavigator` — `map-navigator.tsx`
+
+A render-null React Leaflet component that lives inside `MapContainer`. When
+geocoded `bounds` are available it calls `flyToBounds` to frame all markers.
+Before bounds are available (geocoding still in progress), it geocodes the
+district name as a fallback to set an appropriate initial map view.
+
+### `createSiteIcon(totalSpecimens, anophelesCount)` — `site-icon.tsx`
+
+Creates a Leaflet `DivIcon` (circular div). Radius scales from 8–26px based on
+specimen count (`min + count / 20`, clamped). Color encodes Anopheles count
+across five thresholds: gray (0), blue (1–9), orange (10–49), red (50–99), dark
+red (100+).
+
+---
+
+## Type Boundary
+
+`VillageMarker` is defined in `src/features/operations/lib/use-site-markers.ts`
+(alongside the hook that produces markers) and imported from there by all
+consumers. It was previously defined in `site-map.tsx` (a component file), which
+caused `lib/` code to depend on a component — a boundary violation per the
+project architecture. `site-map.tsx` re-exports the type for any consumers that
+still reference it via that path.
+
+---
+
+## Marker Clustering
+
+`react-leaflet-cluster` wraps `leaflet.markercluster` to group nearby markers
+into cluster bubbles. This prevents markers from overlapping when multiple
+villages geocode to the same or nearby coordinates (e.g. when village names are
+non-standard and fall back to parish or district level).
+
+The `key={positions.size}` on `MarkerClusterGroup` forces the component to
+remount when the geocoded positions Map first becomes populated. Without this,
+`react-leaflet-cluster` does not pick up children that were added after its
+initial render.
+
+---
+
+## PR Description
+
+This pull request implements the Geographical Summary tab within the Operations
+page, displaying village-level markers for a selected district and date range.
+
+**Map & Geocoding (`src/features/operations/components/geographical-summary/`)**
+
+- Added `site-map.tsx`, `MarkerLayer`, and `MapNavigator` to render a Leaflet
+  map with markers sized by specimen count and colored by Anopheles count.
+  Marker icon creation (`L.divIcon`) lives inside `MarkerLayer` to keep the
+  direct Leaflet import within the `ssr: false` boundary. Nearby markers are
+  clustered using `react-leaflet-cluster` to prevent overlap.
+- Added `hooks/use-village-geocode.ts` and `src/app/api/geocode/route.ts` — a
+  server-side Nominatim proxy with rate limiting (1100ms), proper `User-Agent`
+  headers, and 30-day in-memory caching. The client sends one request per
+  village; the server handles the location fallback hierarchy (village → parish
+  → sub-county → district) internally.
+
+**Data Layer (`src/features/operations/lib/use-site-markers.ts`)**
+
+- Added `useSiteMarkers` hook aggregating specimens and sessions into
+  `VillageMarker[]` grouped by village name. Sessions are joined via a
+  `siteId → villageName` map to add session count and last collection date per
+  village.
+
+**Schema Fixes**
+
+- Marked `species`, `sex`, and `abdomenStatus` as `.nullable()` in
+  `get-specimens-count-schema.ts` — the backend uses a
+  `LEFT JOIN specimen_images`, so unclassified specimens return `null` for these
+  fields.
+- Updated `siteSchema` location fields to `.nullable().optional()` to match the
+  backend, which explicitly returns `null` for unpopulated fields rather than
+  omitting them.
+- Removed `programId` from `getSpecimensCountQueryParamsSchema` — the backend
+  ignores it entirely, with program isolation handled server-side via
+  `siteAccess.userSites`.

--- a/.claude/docs/i18n.md
+++ b/.claude/docs/i18n.md
@@ -1,0 +1,56 @@
+# Internationalization (i18n)
+
+All user-facing strings live in `messages/en.json`. We use
+[next-intl](https://next-intl-docs.vercel.app/) to access them.
+
+## Adding a String
+
+Group strings under a namespace that matches the feature:
+
+```json
+{
+    "Review": {
+        "title": "Review Sessions",
+        "emptyState": "No sessions found.",
+        "confirmDelete": "Are you sure you want to delete this session?"
+    }
+}
+```
+
+## Usage
+
+### Server Component
+
+```tsx
+import { getTranslations } from 'next-intl/server';
+
+export default async function ReviewPage() {
+    const t = await getTranslations('Review');
+
+    return <h1>{t('title')}</h1>;
+}
+```
+
+### Client Component
+
+```tsx
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+export function EmptyState() {
+    const t = useTranslations('Review');
+
+    return <p>{t('emptyState')}</p>;
+}
+```
+
+## Rules
+
+- **Never hardcode UI strings** — if it's visible to a user, it belongs in
+  `en.json`
+- Use the namespace that matches the feature (`"Review"`, `"Operations"`,
+  `"Auth"`, etc.)
+- Put shared strings (loading states, errors, generic buttons) under `"Common"`
+- Key names use `camelCase`
+- `getTranslations` → server components; `useTranslations` → client components

--- a/.claude/docs/location-hierarchy-examples.md
+++ b/.claude/docs/location-hierarchy-examples.md
@@ -1,0 +1,161 @@
+1. # CREATE LOCATION TYPES
+
+POST /programs/{program_id}/location-types
+
+Request: { "name": "District" }
+
+Response: { "message": "Location type created successfully", "locationType": {
+"id": 1, "programId": 1, "name": "District" } }
+
+Create hierarchy (top to bottom):
+
+- District (id: 1)
+- SubCounty (id: 2)
+- Parish (id: 3)
+- Village (id: 4)
+- Household (id: 5)
+
+2. # GET LOCATION TYPES FOR A PROGRAM
+
+GET /programs/{program_id}/location-types
+
+Response: { "locationTypes": [ { "id": 1, "programId": 1, "name": "District" },
+{ "id": 2, "programId": 1, "name": "SubCounty" }, { "id": 3, "programId": 1,
+"name": "Parish" }, { "id": 4, "programId": 1, "name": "Village" }, { "id": 5,
+"programId": 1, "name": "Household" } ] }
+
+3. # CREATE LOCATIONS (NEW HIERARCHICAL SCHEMA)
+
+A. Root Location (District): POST /sites/register { "programId": 1,
+"locationTypeId": 1, "name": "Kampala", "isActive": true }
+
+Response: { "message": "Site created successfully", "site": { "siteId": 100,
+"programId": 1, "locationTypeId": 1, "name": "Kampala", "isActive": true,
+"hasData": false, "District": "Kampala" } }
+
+B. Child Location (SubCounty under District): POST /sites/register {
+"programId": 1, "locationTypeId": 2, "parentId": 100, "name": "Rubaga",
+"isActive": true }
+
+Response: { "site": { "siteId": 101, "programId": 1, "locationTypeId": 2,
+"parentId": 100, "name": "Rubaga", "isActive": true, "hasData": false,
+"District": "Kampala", "SubCounty": "Rubaga" } }
+
+C. Leaf Location (Household): POST /sites/register { "programId": 1,
+"locationTypeId": 5, "parentId": 104, "name": "House-001", "isActive": true }
+
+Response: { "site": { "siteId": 105, "programId": 1, "locationTypeId": 5,
+"parentId": 104, "name": "House-001", "isActive": true, "hasData": false,
+"District": "Kampala", "SubCounty": "Rubaga", "Parish": "Namirembe", "Village":
+"Kasubi", "Household": "House-001" } }
+
+4. # CREATE LOCATIONS (OLD FLAT SCHEMA - BACKWARD COMPATIBLE)
+
+POST /sites/register { "programId": 1, "district": "Kampala", "subCounty":
+"Rubaga", "parish": "Namirembe", "villageName": "Kasubi", "houseNumber": "001",
+"healthCenter": "Rubaga HC", "isActive": true }
+
+Response: { "site": { "siteId": 200, "programId": 1, "district": "Kampala",
+"subCounty": "Rubaga", "parish": "Namirembe", "villageName": "Kasubi",
+"houseNumber": "001", "healthCenter": "Rubaga HC", "isActive": true, "hasData":
+false } }
+
+5. # FETCH LOCATIONS LIST (NEW HIERARCHY SCHEMA)
+
+A. All locations for a program: GET /sites?programId=1&limit=20&offset=0
+
+B. Filter by hierarchy (using locationTypeKey/Value): GET
+/sites?programId=1&locationTypeKey=District&locationTypeValue=Kampala
+
+C. Get specific hierarchy level: GET
+/sites?programId=1&locationTypeKey=SubCounty&locationTypeValue=Rubaga
+
+Response: { "sites": [ { "siteId": 100, "programId": 1, "locationTypeId": 1,
+"name": "Kampala", "isActive": true, "hasData": false, "District": "Kampala" },
+{ "siteId": 101, "programId": 1, "locationTypeId": 2, "parentId": 100, "name":
+"Rubaga", "isActive": true, "hasData": false, "District": "Kampala",
+"SubCounty": "Rubaga" } ], "total": 2, "limit": 20, "offset": 0, "hasMore":
+false }
+
+# 5B. FETCH LOCATIONS LIST (OLD FLAT SCHEMA)
+
+A. All locations for a program: GET /sites?programId=2&limit=20&offset=0
+
+B. Filter by old schema fields: GET
+/sites?programId=2&district=Kampala&subCounty=Rubaga
+
+Response: { "sites": [ { "siteId": 200, "programId": 2, "district": "Kampala",
+"subCounty": "Rubaga", "parish": "Namirembe", "villageName": "Kasubi",
+"houseNumber": "001", "healthCenter": "Rubaga HC", "isActive": true, "hasData":
+false } ], "total": 1, "limit": 20, "offset": 0, "hasMore": false }
+
+6. # UGANDA PROGRAM (USES NEW HIERARCHY)
+
+Setup:
+
+1. Create program: POST /programs { "name": "Uganda Malaria", "country":
+   "Uganda" }
+2. Create location types (see section 1)
+3. Create hierarchical locations (see section 3)
+
+Query by hierarchy: GET
+/sites?programId=1&locationTypeKey=District&locationTypeValue=Kampala
+
+All locations inherit parent hierarchy in response.
+
+7. # NON-UGANDA PROGRAM (CAN USE OLD SCHEMA)
+
+Setup:
+
+1. Create program: POST /programs { "name": "Kenya Study", "country": "Kenya" }
+2. Use flat schema for sites (see section 4)
+
+Query by old fields: GET /sites?programId=2&district=Nairobi&healthCenter=Kibera
+HC
+
+8. # GET SINGLE LOCATION DETAILS (NEW HIERARCHY)
+
+GET /sites/105
+
+Response: { "siteId": 105, "programId": 1, "locationTypeId": 5, "parentId": 104,
+"name": "House-001", "isActive": true, "hasData": false, "District": "Kampala",
+"SubCounty": "Rubaga", "Parish": "Namirembe", "Village": "Kasubi", "Household":
+"House-001" }
+
+# 8B. GET SINGLE LOCATION DETAILS (OLD SCHEMA)
+
+GET /sites/200
+
+Response: { "siteId": 200, "programId": 2, "district": "Kampala", "subCounty":
+"Rubaga", "parish": "Namirembe", "villageName": "Kasubi", "houseNumber": "001",
+"healthCenter": "Rubaga HC", "isActive": true }
+
+9. # UPDATE LOCATION (NEW HIERARCHY)
+
+PUT /sites/105 { "name": "House-001-Updated", "isActive": false }
+
+Updates rebuild location_hierarchy cache automatically.
+
+# 9B. UPDATE LOCATION (OLD SCHEMA)
+
+PUT /sites/200 { "district": "Kampala Central", "healthCenter": "New HC" }
+
+10. # KEY DIFFERENCES
+
+OLD SCHEMA:
+
+- Fixed fields: district, subCounty, parish, villageName, houseNumber,
+  healthCenter
+- Flat structure
+- Uganda-specific naming
+
+NEW SCHEMA:
+
+- Dynamic location types per program
+- Parent-child relationships (parentId, locationTypeId)
+- location_hierarchy JSON cache (auto-built)
+- Response includes dynamic keys like { "District": "Kampala", "SubCounty":
+  "Rubaga" }
+- Flexible for any country/hierarchy
+
+BOTH schemas work simultaneously. Old sites stay flat, new sites use hierarchy.

--- a/.claude/docs/schema.md
+++ b/.claude/docs/schema.md
@@ -1,0 +1,405 @@
+# VectorCam API — Database Schema
+
+MySQL database with Sequelize ORM. 26 tables organized across 7 domains.
+
+## Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    programs {
+        int id PK
+        varchar name
+        varchar country
+        varchar access_code
+        varchar form_version
+    }
+
+    location_types {
+        int id PK
+        int program_id FK
+        varchar name
+        int level
+    }
+
+    sites {
+        int id PK
+        int program_id FK
+        int location_type_id FK
+        int parent_id FK
+        varchar name
+        json location_hierarchy
+        boolean is_active
+        boolean has_data
+    }
+
+    users {
+        int id PK
+        int program_id FK
+        varchar email
+        varchar name
+        varchar password_hash
+        int privilege
+        boolean is_developer
+        boolean is_active
+        boolean is_whitelisted
+    }
+
+    user_whitelist {
+        int id PK
+        int program_id FK
+        varchar email
+    }
+
+    site_users {
+        int id PK
+        int user_id FK
+        int site_id FK
+    }
+
+    devices {
+        int id PK
+        int program_id FK
+        varchar model
+        varchar ssaid
+        varchar app_version
+        datetime registered_at
+        datetime submitted_at
+    }
+
+    collection_schedules {
+        int id PK
+        int program_id FK
+        enum cadence_type
+        enum interval_unit
+        int interval_count
+        date effective_start_date
+        date effective_end_date
+    }
+
+    collection_cycles {
+        int id PK
+        int program_id FK
+        int collection_schedule_id FK
+        int cycle_number
+        date start_date
+        date end_date
+    }
+
+    sessions {
+        int id PK
+        int site_id FK
+        int device_id FK
+        int collection_cycle_id FK
+        varchar frontend_id
+        varchar collector_name
+        varchar collector_title
+        datetime collector_last_trained_on
+        datetime collection_date
+        varchar collection_method
+        varchar specimen_condition
+        enum type
+        varchar hardware_id
+        int expected_specimens
+        float latitude
+        float longitude
+        text notes
+        enum state
+        datetime completed_at
+        datetime submitted_at
+    }
+
+    surveillance_forms {
+        int id PK
+        int session_id FK
+        int num_people_slept_in_house
+        boolean was_irs_conducted
+        int months_since_irs
+        int num_llins_available
+        varchar llin_type
+        varchar llin_brand
+        int num_people_slept_under_llin
+    }
+
+    session_units {
+        int id PK
+        int session_id FK
+        varchar frontend_id
+        int unit_order
+    }
+
+    specimens {
+        int id PK
+        int session_id FK
+        int session_unit_id FK
+        int thumbnail_image_id FK
+        varchar specimen_id
+        boolean should_process_further
+        int expected_images
+    }
+
+    specimen_images {
+        int id PK
+        int specimen_id FK
+        text image_key
+        varchar filemd5
+        json metadata
+        varchar species
+        varchar sex
+        varchar abdomen_status
+        datetime captured_at
+    }
+
+    inference_results {
+        int id PK
+        int specimen_image_id FK
+        float bbox_top_left_x
+        float bbox_top_left_y
+        float bbox_width
+        float bbox_height
+        text species_logits
+        text sex_logits
+        text abdomen_status_logits
+        float bbox_confidence
+        int bbox_class_id
+        int species_inference_duration
+        int sex_inference_duration
+        int abdomen_status_inference_duration
+        int bbox_detection_duration
+    }
+
+    multipart_uploads {
+        int id PK
+        int specimen_id FK
+        enum status
+        int current_part
+        int s3_part_number
+        int total_parts
+        varchar s3_upload_id
+        varchar s3_key
+        json s3_part_etags
+        varchar filemd5
+    }
+
+    tus_upload_logs {
+        int id PK
+        int specimen_id FK
+        int image_id FK
+        varchar tus_upload_id
+        enum status
+        varchar requested_image_ref
+        bigint upload_length
+        datetime upload_created_at
+        datetime upload_started_at
+        datetime upload_finished_at
+        text failure_reason
+        text s3_path
+        json metadata
+        json parts
+    }
+
+    forms {
+        int id PK
+        int program_id FK
+        varchar name
+        varchar version
+    }
+
+    form_questions {
+        int id PK
+        int form_id FK
+        int parent_id FK
+        varchar label
+        varchar type
+        boolean required
+        json options
+        int order
+        json prerequisite
+        enum answer_scope
+        boolean is_unit_identity_component
+    }
+
+    form_answers {
+        int id PK
+        int session_id FK
+        int form_id FK
+        int question_id FK
+        varchar frontend_id
+        json value
+        varchar data_type
+        datetime submitted_at
+    }
+
+    annotation_tasks {
+        int id PK
+        int user_id FK
+        varchar title
+        text description
+        enum status
+    }
+
+    annotations {
+        int id PK
+        int annotation_task_id FK
+        int annotator_id FK
+        int specimen_id FK
+        varchar morph_species
+        varchar morph_sex
+        varchar morph_abdomen_status
+        varchar visual_species
+        varchar visual_sex
+        varchar visual_abdomen_status
+        text notes
+        varchar artifacts
+        enum status
+    }
+
+    dhis2_sync_events {
+        int id PK
+        int site_id FK
+        varchar program_stage_id
+        int year
+        int month
+        varchar event_id
+        varchar tracked_entity_instance_id
+        varchar organization_unit_id
+        varchar event_date
+        datetime last_synced_at
+    }
+
+    dhis2_cache {
+        int id PK
+        varchar program_stage_id
+        enum cache_type
+        varchar cache_key
+        text cache_value
+    }
+
+    session_conflict_resolutions {
+        int id PK
+        int resolved_by_user_id
+        datetime resolved_at
+        json session_ids
+        int site_id
+        int month
+        int year
+        json before_data
+        json after_data
+    }
+
+    review_action_logs {
+        int id PK
+        int site_id
+        int year
+        int month
+        varchar action
+        int user_id
+        boolean has_changes
+        json changes
+        json fields
+        json metadata
+    }
+
+    programs ||--o{ location_types : "has"
+    programs ||--o{ sites : "has"
+    programs ||--o{ devices : "has"
+    programs ||--o{ users : "has"
+    programs ||--o{ user_whitelist : "whitelists"
+    programs ||--o{ forms : "defines"
+    programs ||--o{ collection_schedules : "has"
+    programs ||--o{ collection_cycles : "has"
+
+    location_types ||--o{ sites : "classifies"
+    sites ||--o{ sites : "parent/children"
+
+    users ||--o{ site_users : ""
+    sites ||--o{ site_users : ""
+
+    collection_schedules ||--o{ collection_cycles : "generates"
+    collection_cycles ||--o{ sessions : "groups"
+
+    sites ||--o{ sessions : "hosts"
+    devices ||--o{ sessions : "captures"
+    sessions ||--|| surveillance_forms : "has"
+    sessions ||--o{ session_units : "contains"
+
+    sessions ||--o{ specimens : "contains"
+    session_units ||--o{ specimens : "groups"
+    specimens ||--o{ specimen_images : "has"
+    specimen_images ||--o| inference_results : "produces"
+    specimens ||--o{ multipart_uploads : "tracks"
+    specimens ||--o{ tus_upload_logs : "tracks"
+    specimen_images ||--o{ tus_upload_logs : "linked to"
+    specimens }o--o| specimen_images : "thumbnail"
+
+    forms ||--o{ form_questions : "contains"
+    form_questions ||--o{ form_questions : "parent/children"
+    sessions ||--o{ form_answers : "has"
+    forms ||--o{ form_answers : ""
+    form_questions ||--o{ form_answers : ""
+
+    users ||--o{ annotation_tasks : "owns"
+    annotation_tasks ||--o{ annotations : "contains"
+    specimens ||--o{ annotations : "annotated by"
+    users ||--o{ annotations : "annotates"
+
+    sites ||--o{ dhis2_sync_events : "synced in"
+```
+
+## Table Hierarchy
+
+```
+programs
+├── location_types              (hierarchy levels, e.g. district / parish / village)
+├── sites                       (self-referencing tree via parent_id; typed by location_type)
+│   ├── site_users              (user access junction)
+│   └── dhis2_sync_events       (monthly DHIS2 sync records)
+├── devices                     (mobile collection devices)
+├── users                       (auth + role)
+│   ├── site_users              (access control)
+│   └── annotation_tasks        (batch annotation work)
+│       └── annotations         (per-specimen labels)
+├── user_whitelist              (registration allowlist)
+├── collection_schedules        (cadence config: recurring or manual)
+│   └── collection_cycles       (generated time-bounded periods)
+└── forms                       (survey form definitions)
+    └── form_questions          (self-referencing tree via parent_id)
+
+sessions                        (belongs to site + device; optionally grouped by collection_cycle)
+├── surveillance_forms          (1:1 household demographics)
+├── session_units               (ordered sub-units within a session)
+├── specimens                   (mosquito specimens; optionally scoped to a session_unit)
+│   ├── specimen_images         (1:N images per specimen)
+│   │   └── inference_results   (1:1 ML model output)
+│   ├── multipart_uploads       (S3 chunked upload state)
+│   ├── tus_upload_logs         (TUS protocol upload tracking)
+│   └── annotations             (quality labels from annotators)
+└── form_answers                (survey responses, linked to form + question)
+```
+
+## Domain Summary
+
+| Domain                 | Tables                                                                                      | Description                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| **Organization**       | `programs`, `location_types`, `sites`                                                       | Top-level hierarchy; sites form a tree within a program |
+| **Users & Access**     | `users`, `site_users`, `user_whitelist`                                                     | Auth, roles, per-site permissions                       |
+| **Scheduling**         | `collection_schedules`, `collection_cycles`                                                 | Recurring or manual collection cadence                  |
+| **Data Collection**    | `devices`, `sessions`, `session_units`, `surveillance_forms`                                | Field collection sessions and sub-units at sites        |
+| **Specimens**          | `specimens`, `specimen_images`, `inference_results`, `multipart_uploads`, `tus_upload_logs` | Mosquito images and ML inference pipeline               |
+| **Forms**              | `forms`, `form_questions`, `form_answers`                                                   | Configurable survey questions and responses             |
+| **Annotation & Audit** | `annotation_tasks`, `annotations`, `session_conflict_resolutions`, `review_action_logs`     | QA workflow and audit trail                             |
+| **DHIS2 Integration**  | `dhis2_sync_events`, `dhis2_cache`                                                          | External health system sync                             |
+
+## Key Enums
+
+| Table                  | Column          | Values                                                                  |
+| ---------------------- | --------------- | ----------------------------------------------------------------------- |
+| `sessions`             | `type`          | `SURVEILLANCE`, `DATA_COLLECTION`, `CALIBRATION`, `PRACTICE`            |
+| `sessions`             | `state`         | `NEEDS_REVIEW`, `IN_REVIEW`, `CERTIFIED`, `SUBMITTED`, `NOT_APPLICABLE` |
+| `collection_schedules` | `cadence_type`  | `RECURRING`, `MANUAL`                                                   |
+| `collection_schedules` | `interval_unit` | `DAY`, `WEEK`, `MONTH`, `YEAR`                                          |
+| `form_questions`       | `answer_scope`  | `SESSION`, `SESSION_UNIT`                                               |
+| `multipart_uploads`    | `status`        | `pending`, `in_progress`, `completed`, `failed`                         |
+| `tus_upload_logs`      | `status`        | `created`, `in_progress`, `completed`, `failed`                         |
+| `annotation_tasks`     | `status`        | `PENDING`, `IN_PROGRESS`, `COMPLETED`                                   |
+| `annotations`          | `status`        | `PENDING`, `ANNOTATED`, `FLAGGED`                                       |
+| `dhis2_cache`          | `cache_type`    | `orgUnit`, `tei`, `dataElementMap`                                      |

--- a/.claude/docs/web-app.md
+++ b/.claude/docs/web-app.md
@@ -1,0 +1,1275 @@
+Created: Feb 25, 2024
+
+Last Updated: Mar 28, 2026
+
+1. Introduction
+
+The VectorVerify Web Application is a centralized platform designed to support
+data review, validation, and operational monitoring within the VectorCam
+mosquito surveillance ecosystem.
+
+The VectorCam mobile application enables field teams to collect mosquito
+specimens and associated household survey data during vector surveillance
+activities. While this system allows rapid data collection at scale, large
+surveillance programs require additional infrastructure to ensure that the
+collected data is accurate, complete, and operationally useful.
+
+VectorVerify addresses this need by providing a web-based platform for expert
+reviewers, program managers, and researchers to evaluate surveillance data and
+monitor program performance.
+
+The platform serves three primary roles:
+
+    Annotation of mosquito specimens to evaluate machine learning model performance
+
+    Data review and quality control to ensure the integrity of surveillance datasets
+
+    Operational monitoring and analytics to support program management and decision-making
+
+Through these capabilities, VectorVerify transforms raw mosquito observations
+into high-quality surveillance intelligence that can support malaria control
+programs and public health interventions.
+
+These responsibilities match the description in your onboarding guide, where the
+platform performs annotation, structured data review, and operational
+monitoring. 2. System Overview
+
+VectorVerify operates as the central analysis and validation layer of the
+VectorCam ecosystem.
+
+The system integrates with three major components:
+
+VectorCam Mobile Application
+
+Field teams capture mosquito images and associated household survey metadata
+using the mobile application.
+
+VectorCam Backend API
+
+All data collected by the mobile application is transmitted to the backend
+infrastructure where it is stored and processed.
+
+National Health Information Systems
+
+After review and certification, validated surveillance data can be exported to
+national reporting platforms such as DHIS2.
+
+The web application enables authorized users to review surveillance records,
+validate data quality, and monitor surveillance program activity across multiple
+sites and reporting periods. 3. User Roles and Access Control
+
+The VectorVerify platform uses a role-based access control (RBAC) system to
+regulate access to surveillance data and platform functionality. Access
+permissions are determined by two primary factors:
+
+    Permission Level — whether a user can view or modify data
+
+    Scope of Access — whether a user can access data from a single sentinel site or from all sites within a program
+
+This structure ensures that sensitive surveillance data is accessible only to
+authorized users while still allowing appropriate levels of oversight across the
+surveillance program.
+
+The platform defines four access levels. Access Level 0 — Site Viewer
+
+Users assigned to Access Level 0 have read-only access to surveillance data from
+a single sentinel site within a program.
+
+Permissions include:
+
+    Viewing household surveillance records
+
+    Viewing mosquito specimen images
+
+    Viewing dashboard metrics for the assigned site
+
+These users cannot modify data or submit annotations. Access Level 1 — Program
+Viewer
+
+Users assigned to Access Level 1 have read-only access to surveillance data
+across all sentinel sites within a program.
+
+Permissions include:
+
+    Viewing household surveillance records across all sites
+
+    Viewing specimen data and images across the program
+
+    Accessing program-level dashboards and analytics
+
+These users cannot modify data or submit annotations. Access Level 2 — Site
+Editor
+
+Users assigned to Access Level 2 have read and write access to surveillance data
+from a single sentinel site within a program.
+
+Permissions include:
+
+    Viewing household survey submissions
+
+    Editing or correcting site-level surveillance records
+
+    Managing data associated with the assigned site
+
+These users cannot perform specimen annotation. Access Level 3 — Program Editor
+and Annotator
+
+Users assigned to Access Level 3 have read and write access across all sites
+within a program and are authorized to perform specimen annotation.
+
+Permissions include:
+
+    Viewing and modifying surveillance data across all sites
+
+    Performing expert annotation of mosquito specimens
+
+    Reviewing machine learning classification outputs
+
+    Participating in model evaluation workflows
+
+This access level is typically assigned to expert reviewers, program
+supervisors, or researchers responsible for validating surveillance data and
+evaluating model performance. 2. User Stories Authentication and Access Control
+
+As a program official, I want secure authentication so that only authorized
+individuals can access sensitive surveillance data. Specimen Annotation
+
+As an expert reviewer, I want to inspect mosquito images collected in the field
+so that I can verify the predictions generated by the machine learning models.
+
+As an expert reviewer, I want to record the correct species, sex, and abdomen
+status of a specimen so that model performance can be evaluated. Data Review and
+Quality Control
+
+As a district supervisor, I want to review household-level surveillance data so
+that I can confirm that submissions are complete and consistent.
+
+As a reviewer, I want to inspect mosquito specimen records associated with each
+survey so that classification errors can be corrected before the data becomes
+part of the official surveillance record.
+
+As an expert reviewer, I want to certify datasets after review so that they are
+ready for submission to national surveillance systems. Operational Monitoring
+
+As a program manager, I want dashboards that display surveillance activity
+across districts so that I can monitor whether field teams are collecting data
+consistently.
+
+As a decision-maker, I want to identify areas with unusually high mosquito
+populations so that interventions can be prioritized. Data Analysis
+
+As a biostatistician, I want to visualize mosquito population trends over time
+so that I can assess seasonal patterns.
+
+As a researcher, I want to compare entomological data with epidemiological data
+so that correlations between mosquito populations and malaria transmission can
+be analyzed. 5. Functional Requirements Authentication
+
+The system must require authentication using a valid username and password
+before a user can access any platform functionality.
+
+The system must enforce role-based access control based on the defined access
+levels (0–3).
+
+The system must restrict users to viewing and modifying data only within the
+scope permitted by their assigned access level.
+
+The system must automatically terminate inactive user sessions after a
+configurable timeout period.
+
+The system must allow users to reset their password in case it is lost for any
+reason. Surveillance Data Retrieval
+
+The system must retrieve surveillance records from the VectorCam API.
+
+The system must display surveillance records grouped by program, site, session,
+and specimen.
+
+The system must allow users to filter surveillance data using the following
+parameters:
+
+    program
+
+    site
+
+    household
+
+    collection method
+
+    date range
+
+The system must allow users to search for specific surveillance records using
+unique identifiers including:
+
+    household ID
+
+    session ID
+
+    specimen ID
+
+The system must paginate large result sets to maintain responsive performance.
+Specimen Image Review
+
+The system must display mosquito specimen images captured by the VectorCam
+mobile application.
+
+For each specimen, the system must display the machine learning model
+predictions including:
+
+    predicted species
+
+    predicted sex
+
+    predicted abdomen status
+
+    associated confidence scores
+
+The system must display metadata associated with each specimen including:
+
+    session ID
+
+    collection date
+
+    collection site
+
+    household identifier
+
+    collector identity
+
+The system must allow users to zoom and inspect specimen images for detailed
+visual review. Specimen Annotation
+
+The system must allow authorized users (Access Level 3) to submit expert
+annotations for mosquito specimens.
+
+The system must allow annotators to assign the following attributes to a
+specimen:
+
+    species
+
+    sex
+
+    abdomen status
+
+The system must allow annotators to flag specimens with issues including:
+
+    poor image quality
+
+    ambiguous specimen
+
+    incorrect capture
+
+The system must record all annotation submissions along with:
+
+    annotator identity
+
+    timestamp
+
+    original model prediction
+
+    corrected annotation
+
+The system must prevent unauthorized users from modifying annotation records.
+Surveillance Data Review
+
+The system must allow authorized reviewers to inspect household-level
+surveillance metadata.
+
+The system must display the complete set of specimens associated with a
+household surveillance session.
+
+The system must allow reviewers to identify incomplete or inconsistent
+submissions.
+
+The system must allow reviewers to mark surveillance records as:
+
+    verified
+
+    flagged for correction
+
+    pending review
+
+Dataset Certification
+
+The system must allow authorized users to certify reviewed surveillance
+datasets.
+
+Certification must only be permitted once all required review steps have been
+completed.
+
+The system must record the following information for each certification event:
+
+    certifying user
+
+    certification timestamp
+
+    associated reporting period
+
+    number of records certified
+
+Operational Monitoring Dashboards
+
+The system must display aggregate surveillance statistics across all sites
+within a program.
+
+The system must display the number of household surveys conducted per reporting
+period.
+
+The system must display the number of mosquito specimens collected per site.
+
+The system must visualize surveillance activity trends over time using
+time-series graphs.
+
+The system must display geographic distributions of mosquito counts using
+map-based visualizations. Analytical Visualizations
+
+The system must generate charts representing mosquito population composition
+including:
+
+    genus composition
+
+    species composition
+
+    sex composition
+
+    abdominal status composition
+
+The system must generate time-series graphs showing mosquito counts by species.
+
+Users must be able to filter analytical visualizations by:
+
+    district
+
+    sentinel site
+
+    time range
+
+    mosquito species
+
+Epidemiological Data Integration
+
+The system must display malaria epidemiological indicators alongside mosquito
+surveillance data.
+
+The system must allow users to overlay epidemiological data and entomological
+data within the same visualizations.
+
+Users must be able to filter epidemiological datasets by:
+
+    age
+
+    gender
+
+    geographic region
+
+    reporting period
+
+Data Export
+
+The system must allow authorized users to export validated surveillance
+datasets.
+
+The system must support export formats compatible with national surveillance
+systems such as DHIS2.
+
+Exported datasets must only include records that have completed the review and
+certification process. 6. Non-Functional Requirements
+
+The platform must support secure transmission and storage of surveillance data.
+
+The system must comply with relevant data protection regulations.
+
+The platform must provide responsive performance for large datasets.
+
+The interface must minimize the number of actions required to perform common
+tasks. 7. System Architecture and Design Technologies
+
+    Frontend: React, Next.js, TypeScript
+
+    Infrastructure: AWS Cloud (RDS + S3 + EC2)
+
+    Development Tooling: ESLint and Prettier
+
+8. Page Overview Dashboard Purpose
+
+Provide a high-level overview of surveillance activity, data quality, and
+operational status across the program. High-Level Functionality
+
+The dashboard should serve as the landing page for most users. It should
+summarize overall surveillance activity, highlight what needs attention, and
+provide quick entry points into deeper workflows.
+
+It should include:
+
+    summary metrics for surveillance activity
+
+    visibility into pending review work
+
+    visibility into flagged or incomplete records
+
+    trends over time
+
+    filtering by program, site, and date
+
+    quick links into review workflows
+
+Notes
+
+This page aligns most directly with the operational monitoring requirements,
+including aggregate surveillance statistics, surveillance activity trends, and
+site-level visibility. Status
+
+Implementation Partially Complete
+
+Review
+
+The Review feature supports site-level monthly data validation prior to
+submission to national surveillance systems.
+
+The workflow is structured into four sequential pages:
+
+    Site & Month Selection
+
+    Site Surveillance Questions Review
+
+    Specimen Review
+
+    Site Monthly Certification
+
+Review is performed for one site at a time, and certification applies only to
+that site and month.
+
+Site & Month Selection Page
+
+Purpose
+
+The Site & Month Selection Page allows users to select a sentinel site and
+reporting month for review.
+
+This page defines the scope of the review. All subsequent pages operate within
+the selected site and month.
+
+This page helps users answer:
+
+    Which site am I reviewing?
+
+    Which month am I reviewing?
+
+    What is the review status for each site/month?
+
+Page Structure
+
+    Month Selector
+
+        Users select:
+
+            Month
+
+            Year
+
+        This defines the reporting period.
+
+    Site List
+
+        Display sentinel sites for the selected program.
+
+        Each site should display:
+
+            Site name
+
+            District
+
+            Number of sessions submitted
+
+            Review status
+
+            Certification status
+
+    Review Status Indicators
+
+        Each site/month should indicate:
+
+            Not reviewed
+
+            In progress
+
+            Ready for certification
+
+            Certified
+
+        This helps users quickly identify work remaining.
+
+    Actions
+
+        Users can:
+
+            Select site for review
+
+            Resume review in progress
+
+            View certification status
+
+Status
+
+Implementation Complete
+
+Site Surveillance Questions Review Page
+
+Purpose
+
+The Site Surveillance Questions Review Page allows users to review surveillance
+form responses across all sessions submitted for a site during a selected month.
+
+This page helps identify inconsistent or conflicting responses across sessions.
+
+This page helps users answer:
+
+    Are surveillance questions consistent across sessions?
+
+    Are there conflicting responses?
+
+    Are corrections required?
+
+This page is the first validation step in the review workflow.
+
+Page Structure
+
+    Site Context Header
+
+        Display:
+
+            Site name
+
+            District
+
+            Selected month
+
+            Number of sessions
+
+        This provides review context.
+
+    Surveillance Questions Table
+
+        Display surveillance questions as rows, with responses across sessions.
+
+        Example layout:
+
+            Question
+            → Session 1 Response
+            → Session 2 Response
+            → Session 3 Response
+
+        This allows users to quickly identify inconsistencies.
+
+    Conflict Detection
+
+        Highlight:
+
+            Conflicting responses
+
+            Missing responses
+
+            Incomplete entries
+
+        This helps users focus on issues.
+
+    Resolution Actions
+
+        Users can:
+
+            Resolve conflicting entries
+
+            Mark correct response
+
+            Flag sessions for follow-up
+
+            Add notes
+
+    Outcome
+
+        User confirms:
+
+            Surveillance questions are consistent
+
+            Conflicts resolved
+
+            Data ready for specimen review
+
+Status
+
+Implementation Partially Complete
+
+Specimen Review Page
+
+Purpose
+
+The Specimen Review Page allows users to quickly review specimens collected for
+a site during a selected month and correct obvious machine learning errors.
+
+This page focuses on rapid validation, not deep annotation.
+
+This page helps users answer:
+
+    Are predictions reasonable?
+
+    Are there obvious errors?
+
+    Are images acceptable?
+
+This is the second validation step.
+
+Page Structure
+
+    Site Context Header
+
+        Display:
+
+            Household ID
+
+            Sentinel site
+
+            Collection date
+
+            Collector
+
+            Total specimens expected
+
+            Total specimens uploaded
+
+        This provides context for review.
+
+    Specimen Review Workspace
+
+        Display:
+
+            Specimen image
+
+            Model prediction
+
+            Basic metadata
+
+        Users should be able to:
+
+            Flip quickly between specimens
+
+            Approve specimen
+
+            Correct obvious ML errors
+
+            Flag problematic images
+
+    Navigation
+
+        Allow:
+
+            Next specimen
+
+            Previous specimen
+
+            Skip specimen
+
+        This supports rapid review.
+
+    Bulk Approval
+
+        Users should be able to:
+
+            Approve remaining specimens
+
+            Approve all unflagged specimens
+
+        This speeds up workflow.
+
+    Outcome
+
+        User:
+
+            Corrects obvious ML errors
+
+            Approves acceptable specimens
+
+            Flags problematic images
+
+Status
+
+Not Implemented
+
+Site Monthly Certification Page
+
+Purpose
+
+The Site Monthly Certification Page allows users to certify that surveillance
+data for a specific site and month is complete and ready for submission to
+national surveillance systems.
+
+This is the final step in the review workflow.
+
+This page helps users answer:
+
+    Have surveillance questions been reviewed?
+
+    Have specimens been reviewed?
+
+    Is data ready for certification?
+
+Page Structure
+
+    Certification Summary
+
+        Display:
+
+            Site
+
+            Month
+
+            Sessions reviewed
+
+            Specimens reviewed
+
+            Outstanding issues
+
+    Review Status Summary
+
+        Display:
+
+            Surveillance questions review status
+
+            Specimen review status
+
+            Flags remaining
+
+    Certification Actions
+
+        Users can:
+
+            Certify site/month
+
+            Add certification notes
+
+    Certification Metadata
+
+        Record:
+
+            Certifying user
+
+            Timestamp
+
+            Site
+
+            Month
+
+    Outcome
+
+        User certifies:
+
+            Site-level dataset
+
+            Month-level dataset
+
+            Data ready for national surveillance system
+
+Status
+
+Not Implemented Annotation
+
+The Annotation feature supports expert review of mosquito specimens to evaluate
+and improve machine learning performance.
+
+Unlike the Review workflow (which is site + month based), the Annotation
+workflow is task-based, allowing experts to work through assigned or generated
+annotation tasks.
+
+The workflow consists of two primary pages:
+
+    Annotation Tasks List
+
+    Annotation Workspace
+
+Annotation Tasks List Page
+
+Purpose
+
+The Annotation Tasks List Page allows users to view and select annotation tasks.
+
+Annotation tasks represent sets of specimens that require expert labeling for
+purposes such as:
+
+    Model performance evaluation
+
+    Dataset generation
+
+    Quality assurance
+
+    Targeted validation
+
+This page helps users answer:
+
+    What annotation tasks are available?
+
+    Which tasks are assigned to me?
+
+    Which tasks are in progress or complete?
+
+This page serves as the entry point into the annotation workflow.
+
+Page Structure
+
+    Annotation Tasks List
+
+        Display annotation tasks as a list and grouped by status.
+
+        Each task should include:
+
+            Task name
+
+            Task description
+
+            Program or site (if applicable)
+
+            Number of specimens
+
+            Progress (e.g., 25 / 100 annotated)
+
+            Task status
+
+    Task Status
+
+        Each task should indicate:
+
+            Not started
+
+            In progress
+
+            Completed
+
+        This helps users prioritize work.
+
+    Task Filters
+
+        Users should be able to filter tasks by:
+
+            Task status
+
+            Date created
+
+    Task Actions
+
+        Users should be able to:
+
+            Open annotation task
+
+            Resume annotation
+
+            View task details
+
+    Outcome
+
+        User selects:
+
+            Annotation task
+
+            Begins annotation workflow
+
+Annotation Workspace
+
+Purpose
+
+The Annotation Workspace allows users to annotate specimens within a selected
+annotation task.
+
+This page is designed for efficient, focused annotation, allowing users to move
+quickly through specimens.
+
+This page helps users:
+
+    Review specimen images
+
+    Evaluate model predictions
+
+    Assign correct labels
+
+    Flag ambiguous specimens
+
+Page Structure
+
+    Task Context Header
+
+        Display:
+
+            Task name
+
+            Progress
+
+            Remaining specimens
+
+            Annotator identity (optional)
+
+        This helps users understand context and progress.
+
+    Specimen Display
+
+        Display:
+
+            Specimen image
+
+            Basic metadata (optional)
+
+        This is the primary working area.
+
+    Annotation Controls
+
+        Users should be able to assign:
+
+            Genus
+
+            Species
+
+            Sex
+
+            Abdomen status
+
+            Any artifacts in the image (Eg. Blurry, missing parts, etc.)
+
+        These fields represent the core annotation labels.
+
+    Annotation Actions
+
+        Users should be able to:
+
+            Submit annotation
+
+            Skip specimen
+
+            Flag specimen
+
+            Mark as ambiguous
+
+    Navigation
+
+        Allow users to:
+
+            Move to next specimen
+
+            Move to previous specimen
+
+            Return to task list
+
+        This supports efficient annotation.
+
+    Progress Indicator
+
+        Display:
+
+            Number annotated
+
+            Total specimens
+
+            Remaining specimens
+
+        This helps users track progress.
+
+    Outcome
+
+        User:
+
+            Annotates specimens
+
+            Submits labels
+
+            Moves through task
+
+Operations
+
+The Operations feature provides a centralized operational monitoring interface
+for surveillance programs.
+
+This feature allows users to:
+
+    Monitor surveillance activity
+
+    Review catch trends
+
+    Evaluate data quality
+
+    Assess model performance
+
+    Track VHT compliance
+
+The Operations feature is structured as a single screen with multiple tabs, with
+shared filters across all tabs.
+
+Operations Page Structure:
+
+    Global Filters
+
+        These filters apply to all tabs:
+
+            District selector
+
+            Sentinel site selector (optional)
+
+            Time frame selector (month, custom range, etc.)
+
+        These filters define the scope of operational analysis.
+
+Sites Overview Tab
+
+Purpose
+
+Provide a site-level operational overview of surveillance activity.
+
+This tab helps users answer:
+
+    Which sites are active?
+
+    How much data is being collected?
+
+    Where are potential issues?
+
+Page Structure
+
+    Sites List
+
+        Display sentinel sites with:
+
+            Site name
+
+            District
+
+            Number of sessions
+
+            Number of specimens
+
+            Last submission date
+
+            Collector count (optional)
+
+    Expandable Site View
+
+        Users can expand a site to view:
+
+            Surveillance Form Summary
+
+                Key surveillance form responses
+
+                Summary across sessions
+
+            Specimen Summary
+
+                Number of specimens
+
+                Species breakdown (optional)
+
+                Image availability
+
+    Use Cases
+
+        Users can:
+
+            Identify inactive sites
+
+            Compare site activity
+
+            Inspect site-level data
+
+Status
+
+Implementation Complete
+
+Metrics Dashboard Tab
+
+Purpose
+
+Provide high-level operational insights into mosquito surveillance activity.
+
+This tab helps users answer:
+
+    What is the catch trend?
+
+    Where are mosquitoes increasing?
+
+    Is surveillance consistent?
+
+Suggested Metrics and Figures
+
+    Surveillance Activity
+
+        Sessions collected over time (line graph)
+
+        Specimens collected over time (line graph)
+
+        Active sites over time (line graph)
+
+        Sessions per site (bar chart)
+
+    Catch Metrics
+
+        Total specimens by species (bar chart)
+
+        Species composition (pie chart)
+
+        Sex composition (pie chart)
+
+        Abdomen status composition (pie chart)
+
+    Site Comparisons
+
+        Specimens per site (bar chart)
+
+        Sessions per site (bar chart)
+
+        Average specimens per session (bar chart)
+
+    Temporal Trends
+
+        Species trends over time (stacked line graph)
+
+        Mosquito abundance trends (line graph)
+
+        Monthly comparisons (bar chart)
+
+    Data Quality Metrics
+
+        Sessions missing specimens
+
+        Incomplete sessions
+
+        Flagged sessions
+
+        Review completion rate
+
+    Optional
+
+        Indoor vs outdoor collection trends
+
+        Trap method comparisons
+
+        Collector-level comparisons
+
+Status
+
+Implementation In Progress
+
+Model Accuracy Tab
+
+Purpose
+
+Provide model performance monitoring based on annotation data.
+
+This tab helps users answer:
+
+    How accurate is the model?
+
+    Where is the model struggling?
+
+    Is performance improving over time?
+
+Page Structure
+
+    Confusion Matrix
+
+        Display confusion matrix comparing:
+
+            Model prediction
+
+            Annotation labels
+
+        Example:
+
+            Species Confusion Matrix
+
+            Rows: True labels (annotation)
+
+            Columns: Model predictions
+
+    Accuracy Metrics
+
+        Display:
+
+            Overall accuracy
+
+            Per-species accuracy
+
+            Precision / recall (optional)
+
+            Confusion rate between species
+
+    Trends over Time
+
+        Accuracy over time
+
+        Accuracy by site
+
+        Accuracy by device (optional)
+
+    Use Cases
+
+        Users can:
+
+            Monitor model performance
+
+            Identify problematic species
+
+            Track improvements after retraining
+
+Status
+
+Not Implemented
+
+VHT Compliance Tab
+
+Purpose
+
+Monitor field team compliance and operational consistency.
+
+This tab helps users answer:
+
+    Are VHTs collecting data consistently?
+
+    Are some sites underperforming?
+
+    Is surveillance coverage adequate?
+
+Suggested Metrics
+
+    Activity Metrics
+
+        Sessions per VHT
+
+        Specimens per VHT
+
+        Active VHTs over time
+
+    Coverage Metrics
+
+        Households visited
+
+        Sessions per site
+
+        Sessions per district
+
+    Compliance Metrics
+
+        Days with submissions
+
+        Missed collection days
+
+        Average sessions per week
+
+    Performance Metrics
+
+        Specimens per session
+
+        Incomplete session rate
+
+        Review issues per VHT
+
+    Optional
+
+        VHT leaderboard
+
+        VHT activity heatmap
+
+Status
+
+Not Implemented

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: grill-me
+description:
+    Interview the user relentlessly about a plan or design until reaching shared
+    understanding, resolving each branch of the decision tree. Use when user
+    wants to stress-test a plan, get grilled on their design, or mentions "grill
+    me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a
+shared understanding. Walk down each branch of the design tree, resolving
+dependencies between decisions one-by-one. For each question, provide your
+recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase
+instead.

--- a/.claude/skills/grill-with-docs/ADR-FORMAT.md
+++ b/.claude/skills/grill-with-docs/ADR-FORMAT.md
@@ -1,0 +1,70 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`,
+`0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording _that_ a
+decision was made and _why_ — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter
+  (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when
+  decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth
+  remembering
+- **Consequences** — only when non-obvious downstream effects need to be called
+  out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and
+   wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you
+   picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not
+surprising, nobody will wonder why. If there was no real alternative, there's
+nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is
+  event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate
+  via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth
+  provider, deployment target. Not every library — just the ones that would take
+  a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer
+  context; other contexts reference it by ID only." The explicit no-s are as
+  valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL
+  instead of an ORM because X." Anything where a reasonable reader would assume
+  the opposite. These stop the next engineer from "fixing" something that was
+  deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of
+  compliance requirements." "Response times must be under 200ms because of the
+  partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered
+  GraphQL and picked REST for subtle reasons, record it — otherwise someone will
+  suggest GraphQL again in six months.

--- a/.claude/skills/grill-with-docs/CONTEXT-FORMAT.md
+++ b/.claude/skills/grill-with-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,93 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**: {A concise description of the term} _Avoid_: Purchase, transaction
+
+**Invoice**: A request for payment sent to a customer after delivery. _Avoid_:
+Bill, payment request
+
+**Customer**: A person or organization that places orders. _Avoid_: Client,
+buyer, account
+
+## Relationships
+
+- An **Order** produces one or more **Invoices**
+- An **Invoice** belongs to exactly one **Customer**
+
+## Example dialogue
+
+> **Dev:** "When a **Customer** places an **Order**, do we create the
+> **Invoice** immediately?" **Domain expert:** "No — an **Invoice** is only
+> generated once a **Fulfillment** is confirmed."
+
+## Flagged ambiguities
+
+- "account" was used to mean both **Customer** and **User** — resolved: these
+  are distinct concepts.
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the
+  best one and list the others as aliases to avoid.
+- **Flag conflicts explicitly.** If a term is used ambiguously, call it out in
+  "Flagged ambiguities" with a clear resolution.
+- **Keep definitions tight.** One sentence max. Define what it IS, not what it
+  does.
+- **Show relationships.** Use bold term names and express cardinality where
+  obvious.
+- **Only include terms specific to this project's context.** General programming
+  concepts (timeouts, error types, utility patterns) don't belong even if the
+  project uses them extensively. Before adding a term, ask: is this a concept
+  unique to this context, or a general programming concept? Only the former
+  belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms
+  belong to a single cohesive area, a flat list is fine.
+- **Write an example dialogue.** A conversation between a dev and a domain
+  expert that demonstrates how the terms interact naturally and clarifies
+  boundaries between related concepts.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts,
+where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes
+  payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and
+  shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment
+  consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events;
+  Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is
+  resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If
+unclear, ask.

--- a/.claude/skills/grill-with-docs/SKILL.md
+++ b/.claude/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: grill-with-docs
+description:
+    Grilling session that challenges your plan against the existing domain
+    model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs)
+    inline as decisions crystallise. Use when user wants to stress-test a plan
+    against their project's language and documented decisions.
+---
+
+<what-to-do>
+
+Interview me relentlessly about every aspect of this plan until we reach a
+shared understanding. Walk down each branch of the design tree, resolving
+dependencies between decisions one-by-one. For each question, provide your
+recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before
+continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase
+instead.
+
+</what-to-do>
+
+<supporting-info>
+
+## Domain awareness
+
+During codebase exploration, also look for existing documentation:
+
+### File structure
+
+This project keeps all Claude context under `.claude/`:
+
+```
+.claude/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-example.md
+│       └── 0002-example.md
+└── skills/
+```
+
+Create files lazily — only when you have something to write. If no
+`.claude/CONTEXT.md` exists, create one when the first term is resolved. If no
+`.claude/docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in
+`.claude/CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as
+X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term.
+"You're saying 'account' — do you mean the Customer or the User? Those are
+different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific
+scenarios. Invent scenarios that probe edge cases and force the user to be
+precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you
+find a contradiction, surface it: "Your code cancels entire Orders, but you just
+said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `.claude/CONTEXT.md` right there. Don't batch
+these up — capture them as they happen. Use the format in
+[CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+Don't couple `.claude/CONTEXT.md` to implementation details. Only include terms that are
+meaningful to domain experts.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do
+   it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you
+   picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in
+[ADR-FORMAT.md](./ADR-FORMAT.md).
+
+</supporting-info>

--- a/.claude/skills/grill-with-docs/SKILL.md
+++ b/.claude/skills/grill-with-docs/SKILL.md
@@ -51,8 +51,8 @@ Create files lazily — only when you have something to write. If no
 ### Challenge against the glossary
 
 When the user uses a term that conflicts with the existing language in
-`.claude/CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as
-X, but you seem to mean Y — which is it?"
+`.claude/CONTEXT.md`, call it out immediately. "Your glossary defines
+'cancellation' as X, but you seem to mean Y — which is it?"
 
 ### Sharpen fuzzy language
 
@@ -78,8 +78,8 @@ When a term is resolved, update `.claude/CONTEXT.md` right there. Don't batch
 these up — capture them as they happen. Use the format in
 [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
 
-Don't couple `.claude/CONTEXT.md` to implementation details. Only include terms that are
-meaningful to domain experts.
+Don't couple `.claude/CONTEXT.md` to implementation details. Only include terms
+that are meaningful to domain experts.
 
 ### Offer ADRs sparingly
 

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: tdd
+description:
+    Test-driven development with red-green-refactor loop. Use when user wants to
+    build features or fix bugs using TDD, mentions "red-green-refactor", wants
+    integration tests, or asks for test-first development.
+---
+
+# Test-Driven Development
+
+## Philosophy
+
+**Core principle**: Tests should verify behavior through public interfaces, not
+implementation details. Code can change entirely; tests shouldn't.
+
+**Good tests** are integration-style: they exercise real code paths through
+public APIs. They describe _what_ the system does, not _how_ it does it. A good
+test reads like a specification - "user can checkout with valid cart" tells you
+exactly what capability exists. These tests survive refactors because they don't
+care about internal structure.
+
+**Bad tests** are coupled to implementation. They mock internal collaborators,
+test private methods, or verify through external means (like querying a database
+directly instead of using the interface). The warning sign: your test breaks
+when you refactor, but behavior hasn't changed. If you rename an internal
+function and tests fail, those tests were testing implementation, not behavior.
+
+See [tests.md](tests.md) for examples and [mocking.md](mocking.md) for mocking
+guidelines.
+
+## Anti-Pattern: Horizontal Slices
+
+**DO NOT write all tests first, then all implementation.** This is "horizontal
+slicing" - treating RED as "write all tests" and GREEN as "write all code."
+
+This produces **crap tests**:
+
+- Tests written in bulk test _imagined_ behavior, not _actual_ behavior
+- You end up testing the _shape_ of things (data structures, function
+  signatures) rather than user-facing behavior
+- Tests become insensitive to real changes - they pass when behavior breaks,
+  fail when behavior is fine
+- You outrun your headlights, committing to test structure before understanding
+  the implementation
+
+**Correct approach**: Vertical slices via tracer bullets. One test → one
+implementation → repeat. Each test responds to what you learned from the
+previous cycle. Because you just wrote the code, you know exactly what behavior
+matters and how to verify it.
+
+```
+WRONG (horizontal):
+  RED:   test1, test2, test3, test4, test5
+  GREEN: impl1, impl2, impl3, impl4, impl5
+
+RIGHT (vertical):
+  RED→GREEN: test1→impl1
+  RED→GREEN: test2→impl2
+  RED→GREEN: test3→impl3
+  ...
+```
+
+## Workflow
+
+### 1. Planning
+
+When exploring the codebase, use the project's domain glossary so that test
+names and interface vocabulary match the project's language, and respect ADRs in
+the area you're touching.
+
+Before writing any code:
+
+- [ ] Confirm with user what interface changes are needed
+- [ ] Confirm with user which behaviors to test (prioritize)
+- [ ] Identify opportunities for [deep modules](deep-modules.md) (small
+      interface, deep implementation)
+- [ ] Design interfaces for [testability](interface-design.md)
+- [ ] List the behaviors to test (not implementation steps)
+- [ ] Get user approval on the plan
+
+Ask: "What should the public interface look like? Which behaviors are most
+important to test?"
+
+**You can't test everything.** Confirm with the user exactly which behaviors
+matter most. Focus testing effort on critical paths and complex logic, not every
+possible edge case.
+
+### 2. Tracer Bullet
+
+Write ONE test that confirms ONE thing about the system:
+
+```
+RED:   Write test for first behavior → test fails
+GREEN: Write minimal code to pass → test passes
+```
+
+This is your tracer bullet - proves the path works end-to-end.
+
+### 3. Incremental Loop
+
+For each remaining behavior:
+
+```
+RED:   Write next test → fails
+GREEN: Minimal code to pass → passes
+```
+
+Rules:
+
+- One test at a time
+- Only enough code to pass current test
+- Don't anticipate future tests
+- Keep tests focused on observable behavior
+
+### 4. Refactor
+
+After all tests pass, look for [refactor candidates](refactoring.md):
+
+- [ ] Extract duplication
+- [ ] Deepen modules (move complexity behind simple interfaces)
+- [ ] Apply SOLID principles where natural
+- [ ] Consider what new code reveals about existing code
+- [ ] Run tests after each refactor step
+
+**Never refactor while RED.** Get to GREEN first.
+
+## Checklist Per Cycle
+
+```
+[ ] Test describes behavior, not implementation
+[ ] Test uses public interface only
+[ ] Test would survive internal refactor
+[ ] Code is minimal for this test
+[ ] No speculative features added
+```

--- a/.claude/skills/tdd/deep-modules.md
+++ b/.claude/skills/tdd/deep-modules.md
@@ -1,0 +1,33 @@
+# Deep Modules
+
+From "A Philosophy of Software Design":
+
+**Deep module** = small interface + lots of implementation
+
+```
+┌─────────────────────┐
+│   Small Interface   │  ← Few methods, simple params
+├─────────────────────┤
+│                     │
+│                     │
+│  Deep Implementation│  ← Complex logic hidden
+│                     │
+│                     │
+└─────────────────────┘
+```
+
+**Shallow module** = large interface + little implementation (avoid)
+
+```
+┌─────────────────────────────────┐
+│       Large Interface           │  ← Many methods, complex params
+├─────────────────────────────────┤
+│  Thin Implementation            │  ← Just passes through
+└─────────────────────────────────┘
+```
+
+When designing interfaces, ask:
+
+- Can I reduce the number of methods?
+- Can I simplify the parameters?
+- Can I hide more complexity inside?

--- a/.claude/skills/tdd/interface-design.md
+++ b/.claude/skills/tdd/interface-design.md
@@ -1,0 +1,31 @@
+# Interface Design for Testability
+
+Good interfaces make testing natural:
+
+1. **Accept dependencies, don't create them**
+
+    ```typescript
+    // Testable
+    function processOrder(order, paymentGateway) {}
+
+    // Hard to test
+    function processOrder(order) {
+        const gateway = new StripeGateway();
+    }
+    ```
+
+2. **Return results, don't produce side effects**
+
+    ```typescript
+    // Testable
+    function calculateDiscount(cart): Discount {}
+
+    // Hard to test
+    function applyDiscount(cart): void {
+        cart.total -= discount;
+    }
+    ```
+
+3. **Small surface area**
+    - Fewer methods = fewer tests needed
+    - Fewer params = simpler test setup

--- a/.claude/skills/tdd/mocking.md
+++ b/.claude/skills/tdd/mocking.md
@@ -1,0 +1,61 @@
+# When to Mock
+
+Mock at **system boundaries** only:
+
+- External APIs (payment, email, etc.)
+- Databases (sometimes - prefer test DB)
+- Time/randomness
+- File system (sometimes)
+
+Don't mock:
+
+- Your own classes/modules
+- Internal collaborators
+- Anything you control
+
+## Designing for Mockability
+
+At system boundaries, design interfaces that are easy to mock:
+
+**1. Use dependency injection**
+
+Pass external dependencies in rather than creating them internally:
+
+```typescript
+// Easy to mock
+function processPayment(order, paymentClient) {
+    return paymentClient.charge(order.total);
+}
+
+// Hard to mock
+function processPayment(order) {
+    const client = new StripeClient(process.env.STRIPE_KEY);
+    return client.charge(order.total);
+}
+```
+
+**2. Prefer SDK-style interfaces over generic fetchers**
+
+Create specific functions for each external operation instead of one generic
+function with conditional logic:
+
+```typescript
+// GOOD: Each function is independently mockable
+const api = {
+    getUser: id => fetch(`/users/${id}`),
+    getOrders: userId => fetch(`/users/${userId}/orders`),
+    createOrder: data => fetch('/orders', { method: 'POST', body: data }),
+};
+
+// BAD: Mocking requires conditional logic inside the mock
+const api = {
+    fetch: (endpoint, options) => fetch(endpoint, options),
+};
+```
+
+The SDK approach means:
+
+- Each mock returns one specific shape
+- No conditional logic in test setup
+- Easier to see which endpoints a test exercises
+- Type safety per endpoint

--- a/.claude/skills/tdd/refactoring.md
+++ b/.claude/skills/tdd/refactoring.md
@@ -1,0 +1,10 @@
+# Refactor Candidates
+
+After TDD cycle, look for:
+
+- **Duplication** → Extract function/class
+- **Long methods** → Break into private helpers (keep tests on public interface)
+- **Shallow modules** → Combine or deepen
+- **Feature envy** → Move logic to where data lives
+- **Primitive obsession** → Introduce value objects
+- **Existing code** the new code reveals as problematic

--- a/.claude/skills/tdd/tests.md
+++ b/.claude/skills/tdd/tests.md
@@ -1,0 +1,62 @@
+# Good and Bad Tests
+
+## Good Tests
+
+**Integration-style**: Test through real interfaces, not mocks of internal
+parts.
+
+```typescript
+// GOOD: Tests observable behavior
+test('user can checkout with valid cart', async () => {
+    const cart = createCart();
+    cart.add(product);
+    const result = await checkout(cart, paymentMethod);
+    expect(result.status).toBe('confirmed');
+});
+```
+
+Characteristics:
+
+- Tests behavior users/callers care about
+- Uses public API only
+- Survives internal refactors
+- Describes WHAT, not HOW
+- One logical assertion per test
+
+## Bad Tests
+
+**Implementation-detail tests**: Coupled to internal structure.
+
+```typescript
+// BAD: Tests implementation details
+test('checkout calls paymentService.process', async () => {
+    const mockPayment = jest.mock(paymentService);
+    await checkout(cart, payment);
+    expect(mockPayment.process).toHaveBeenCalledWith(cart.total);
+});
+```
+
+Red flags:
+
+- Mocking internal collaborators
+- Testing private methods
+- Asserting on call counts/order
+- Test breaks when refactoring without behavior change
+- Test name describes HOW not WHAT
+- Verifying through external means instead of interface
+
+```typescript
+// BAD: Bypasses interface to verify
+test('createUser saves to database', async () => {
+    await createUser({ name: 'Alice' });
+    const row = await db.query('SELECT * FROM users WHERE name = ?', ['Alice']);
+    expect(row).toBeDefined();
+});
+
+// GOOD: Verifies through interface
+test('createUser makes user retrievable', async () => {
+    const user = await createUser({ name: 'Alice' });
+    const retrieved = await getUser(user.id);
+    expect(retrieved.name).toBe('Alice');
+});
+```

--- a/.claude/skills/to-prd/SKILL.md
+++ b/.claude/skills/to-prd/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: to-prd
+description:
+    Turn the current conversation context into a PRD and publish it to
+    .claude/prds/<branch-name>/. Use when user wants to create a PRD from the
+    current context.
+---
+
+This skill takes the current conversation context and codebase understanding and
+produces a PRD. Do NOT interview the user — just synthesize what you already
+know.
+
+The issue tracker and triage label vocabulary should have been provided to you —
+run `/setup-matt-pocock-skills` if not.
+
+## Output location
+
+PRDs are always written to **`.claude/prds/<branch-name>/<prd-name>.md`**.
+
+- Get the current branch name with `git branch --show-current`.
+- Use the branch name as the folder (e.g. `VCV-183-1`).
+- Name the file after the feature or ticket (e.g. `VCV-183-export-tab.md`).
+- Never write PRDs to a root-level `prds/` folder or anywhere outside
+  `.claude/prds/`.
+
+Example path: `.claude/prds/VCV-183-1/VCV-183-export-tab.md`
+
+PRDs should also be batched into commit sized pieces so that they can be easily
+reviewed and digested by the engineering team.
+
+## Process
+
+1. Explore the repo to understand the current state of the codebase, if you
+   haven't already. Use the project's domain glossary vocabulary throughout the
+   PRD, and respect any ADRs in the area you're touching.
+
+2. Sketch out the major modules you will need to build or modify to complete the
+   implementation. Actively look for opportunities to extract deep modules that
+   can be tested in isolation.
+
+A deep module (as opposed to a shallow module) is one which encapsulates a lot
+of functionality in a simple, testable interface which rarely changes.
+
+Check with the user that these modules match their expectations. Check with the
+user which modules they want tests written for.
+
+3. Write the PRD using the template below
+
+<prd-template>
+
+## Problem Statement
+
+The problem that the user is facing, from the user's perspective.
+
+## Solution
+
+The solution to the problem, from the user's perspective.
+
+## User Stories
+
+A LONG, numbered list of user stories. Each user story should be in the format
+of:
+
+1. As an <actor>, I want a <feature>, so that <benefit>
+
+<user-story-example>
+1. As a mobile bank customer, I want to see balance on my accounts, so that I can make better informed decisions about my spending
+</user-story-example>
+
+This list of user stories should be extremely extensive and cover all aspects of
+the feature.
+
+## Implementation Decisions
+
+A list of implementation decisions that were made. This can include:
+
+- The modules that will be built/modified
+- The interfaces of those modules that will be modified
+- Technical clarifications from the developer
+- Architectural decisions
+- Schema changes
+- API contracts
+- Specific interactions
+
+Do NOT include specific file paths or code snippets. They may end up being
+outdated very quickly.
+
+## Testing Decisions
+
+A list of testing decisions that were made. Include:
+
+- A description of what makes a good test (only test external behavior, not
+  implementation details)
+- Which modules will be tested
+- Prior art for the tests (i.e. similar types of tests in the codebase)
+
+## Out of Scope
+
+A description of the things that are out of scope for this PRD.
+
+## Further Notes
+
+Any further notes about the feature.
+
+</prd-template>


### PR DESCRIPTION
## Summary

Exports the `.claude/` configuration directory so all team members get the same
Claude Code setup when they clone the repo.

### What's included

**Configuration**
- `.claude/CLAUDE.md` — project instructions loaded into every Claude session (code standards, architecture patterns, naming conventions)
- `.claude/CONTEXT.md` — domain language reference (roles, workflows, terminology)
- `.claude/.gitignore` — excludes personal/ephemeral files from git (`prds/`, `plans/`, `settings.local.json`) so teammates' session files don't get accidentally committed

**Reference Docs** (`.claude/docs/`)
| File | Description |
|---|---|
| `architecture.md` | System architecture overview |
| `best-practices.md` | Project-specific coding conventions |
| `schema.md` | Full database schema — 26 tables, ERD, enums (updated to match current API) |
| `web-app.md` | Web app structure and patterns |
| `i18n.md` | Guide for using `en.json` with next-intl |
| `geographical-summary.md` | Location/geography data model notes |
| `location-hierarchy-examples.md` | Example location hierarchy structures |
| `form-api-usecases.md` | Custom form API use case reference |
| `feature-scope-gap.md` | Feature scope and gap analysis |

**Skills** (`.claude/skills/`) — slash commands available in any Claude session
| Skill | What it does |
|---|---|
| `tdd` | Red-green-refactor TDD loop with integration test support (**currently we have no tests setup**) |
| `grill-me` | Interviews you about a plan until all design decisions are resolved |
| `grill-with-docs` | Stress-tests a plan against the domain model; updates `CONTEXT.md` and ADRs inline |
| `to-prd` | Converts the current conversation into a PRD saved under `.claude/prds/` |

### What's excluded

`prds/`, `plans/`, `settings.local.json`, and `projects/` are gitignored — these contain personal session files and ticket-specific work that shouldn't be shared.
