### PR TITLE
VCV-214: Stat badges should represent sites not sessions

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -104,10 +104,10 @@ annotation. _Avoid_: Image-based
 - "Sentinel site" (web app doc language) and "leaf site" (API code language)
   refer to the same concept — a site with `has_data = true`. Use "Sentinel Site"
   in UI-facing contexts.
-- "Household" is informal field language for a **Sentinel Site** — the
-  physical house (leaf node in the location hierarchy) where a VHT collects
-  specimens. A Sentinel Site can have multiple Sessions in a cycle. Use
-  "Sentinel Site" in code and UI-facing language; avoid "household".
+- "Household" is informal field language for a **Sentinel Site** — the physical
+  house (leaf node in the location hierarchy) where a VHT collects specimens. A
+  Sentinel Site can have multiple Sessions in a cycle. Use "Sentinel Site" in
+  code and UI-facing language; avoid "household".
 
 - "Expert Reviewer" was used in user stories to mean **VCO** — resolved: use VCO
 - "Annotation" and "Review" are two distinct workflows, not two distinct roles —

--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -104,8 +104,10 @@ annotation. _Avoid_: Image-based
 - "Sentinel site" (web app doc language) and "leaf site" (API code language)
   refer to the same concept — a site with `has_data = true`. Use "Sentinel Site"
   in UI-facing contexts.
-- "Household" is informal shorthand for a Session and its associated
-  Surveillance Form — there is no Household entity in the data model.
+- "Household" is informal field language for a **Sentinel Site** — the
+  physical house (leaf node in the location hierarchy) where a VHT collects
+  specimens. A Sentinel Site can have multiple Sessions in a cycle. Use
+  "Sentinel Site" in code and UI-facing language; avoid "household".
 
 - "Expert Reviewer" was used in user stories to mean **VCO** — resolved: use VCO
 - "Annotation" and "Review" are two distinct workflows, not two distinct roles —

--- a/messages/en.json
+++ b/messages/en.json
@@ -22,5 +22,9 @@
         "welcomeBack": "Welcome back",
         "createAccount": "Create your account",
         "accessDenied": "Access Denied"
+    },
+    "ReviewSitesList": {
+        "needsReview": "Needs Review",
+        "sitesNeedReview": "{count, plural, one {# site needs review} other {# sites need review}}"
     }
 }

--- a/src/features/review/sites-list/components/sites/review-site-hierarchy.tsx
+++ b/src/features/review/sites-list/components/sites/review-site-hierarchy.tsx
@@ -5,6 +5,8 @@ import SiteHierarchy from '@/features/review/components/site-hierarchy';
 import ReviewVisitCoverageBadge from './review-visit-coverage-badge';
 import ReviewSiteLeafRows from './review-site-leaf-rows';
 import type { ReviewSiteSessionSummary } from '../../utils/review-site-session-summary';
+import { useTranslations } from 'next-intl';
+import { Fragment } from 'react/jsx-runtime';
 
 function getVisitCoverageBackgroundColor(
     percentage: number,
@@ -34,6 +36,7 @@ export default function ReviewSiteHierarchy({
     expandedSitePaths,
     onTogglePath,
 }: ReviewSiteHierarchyProps) {
+    const t = useTranslations('ReviewSitesList');
     return (
         <SiteHierarchy
             sites={sites}
@@ -58,21 +61,21 @@ export default function ReviewSiteHierarchy({
                     sitesInGroup.length > 0
                         ? Math.round((visitedCount / sitesInGroup.length) * 100)
                         : 0;
-                const needsReviewTotal = sitesInGroup.reduce(
-                    (sum, site) =>
-                        sum +
+                const needsReviewSiteCount = sitesInGroup.filter(
+                    site =>
                         (sessionCountsBySiteId.get(site.siteId)
-                            ?.needsReviewCount ?? 0),
-                    0,
-                );
+                            ?.needsReviewCount ?? 0) > 0,
+                ).length;
                 return {
                     headerClassName:
                         getVisitCoverageBackgroundColor(visitedPercentage),
                     summaryContent: (
-                        <>
-                            {needsReviewTotal > 0 && (
+                        <Fragment>
+                            {needsReviewSiteCount > 0 && (
                                 <span className="text-destructive text-xs tabular-nums">
-                                    {`${needsReviewTotal} ${needsReviewTotal === 1 ? 'needs' : 'need'} review`}
+                                    {t('sitesNeedReview', {
+                                        count: needsReviewSiteCount,
+                                    })}
                                 </span>
                             )}
                             <span className="text-muted-foreground text-xs tabular-nums">
@@ -81,7 +84,7 @@ export default function ReviewSiteHierarchy({
                             <ReviewVisitCoverageBadge
                                 visitedPercentage={visitedPercentage}
                             />
-                        </>
+                        </Fragment>
                     ),
                 };
             }}

--- a/src/features/review/sites-list/components/sites/review-site-leaf-rows.tsx
+++ b/src/features/review/sites-list/components/sites/review-site-leaf-rows.tsx
@@ -5,6 +5,7 @@ import { Lock, MapPin } from 'lucide-react';
 import Link from 'next/link';
 import { Fragment } from 'react';
 import { endOfMonth, format, parseISO, startOfMonth } from 'date-fns';
+import { useTranslations } from 'next-intl';
 import { type ReviewSiteSessionSummary } from '../../utils/review-site-session-summary';
 
 interface ReviewSiteLeafRowsProps {
@@ -34,6 +35,7 @@ export default function ReviewSiteLeafRows({
     sessionCountsBySiteId,
     monthKey,
 }: ReviewSiteLeafRowsProps) {
+    const t = useTranslations('ReviewSitesList');
     const startDate = format(startOfMonth(parseISO(monthKey)), 'yyyy-MM-dd');
     const endDate = format(endOfMonth(parseISO(monthKey)), 'yyyy-MM-dd');
 
@@ -88,7 +90,7 @@ export default function ReviewSiteLeafRows({
                         <div className="flex items-center gap-2">
                             {needsReviewCount > 0 && (
                                 <Badge variant="destructive">
-                                    {`${needsReviewCount} ${needsReviewCount === 1 ? 'needs' : 'need'} review`}
+                                    {t('needsReview')}
                                 </Badge>
                             )}
                             {isSubmitted ? (


### PR DESCRIPTION
## Summary

- **Sentinel Site (leaf) row**: Replace the session-count badge (`"2 needs review"`) with a plain `"Needs Review"` label
- **Parent group row**: Replace the session-count summary (`"7 need review"`) with a count of Sentinel Sites that have at least one session needing review (`"3 sites need review"`)
- Added `ReviewSitesList` i18n namespace to `messages/en.json` for both new strings.
