### PR TITLE
VCV-217: fix bug with persisting notes

### DIFF
--- a/src/features/annotation/task-details/components/workspace/annotation-form.tsx
+++ b/src/features/annotation/task-details/components/workspace/annotation-form.tsx
@@ -434,6 +434,7 @@ export default function AnnotationForm({
                                     </FieldLabel>
                                     <Textarea
                                         {...field}
+                                        value={field.value ?? ''}
                                         id="annotation-rhf-notes"
                                         placeholder={
                                             watchIsFlagged


### PR DESCRIPTION
Bugfix: add `value={field.value ?? ''}` to textarea, so it clears after reset