### PR TITLE
VCV-237: collection timezone display

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -77,6 +77,18 @@ by a VCO during Review (the exception case). Note: adoption is not yet universal
 established, produce sessions with no cycle assignment. _Avoid_: Reporting
 period, month (when a custom cycle is in use)
 
+**Timezone**: The IANA timezone name (e.g. `Africa/Kampala`) used to display
+Session collection dates and Collection Cycle windows in the region where
+collection happened — never the reviewer's browser timezone. Owned by the
+**Collection Schedule** and denormalized onto every **Collection Cycle** it
+generates. Because a Schedule is program-scoped with only one active per program
+(and all a program's sites share it), **a Site is governed by exactly one
+timezone at a time** — a single Site whose Sessions span two timezones is a data
+error, not a valid state. The value is unvalidated free text on the backend and
+may be `null` (cycles predating the column, or schedules with no timezone); the
+web app falls back to UTC for display when it is `null`. _Avoid_: browser
+timezone, local time, offset
+
 **Session**: A single field data collection event at a site, conducted by a VHT
 using the VectorCam mobile app. Only sessions of type `SURVEILLANCE` enter the
 Review workflow. `collectionCycleId` is nullable — sessions from programs

--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -86,8 +86,14 @@ generates. Because a Schedule is program-scoped with only one active per program
 timezone at a time** — a single Site whose Sessions span two timezones is a data
 error, not a valid state. The value is unvalidated free text on the backend and
 may be `null` (cycles predating the column, or schedules with no timezone); the
-web app falls back to UTC for display when it is `null`. _Avoid_: browser
-timezone, local time, offset
+web app falls back to UTC for display when it is `null`. Timezone is
+**display-only**: which Cycle a Session belongs to is decided by the backend as
+a raw instant comparison (`cycle.startDate <= collectionDate < cycle.endDate`)
+and is timezone-independent — the frontend timezone can never move a Session
+between Cycles, only change the calendar day a `collectionDate` is _rendered_
+as. (The backend exposes no get-single-cycle endpoint and Sessions carry no
+timezone of their own — it lives only on the Cycle.) _Avoid_: browser timezone,
+local time, offset
 
 **Session**: A single field data collection event at a site, conducted by a VHT
 using the VectorCam mobile app. Only sessions of type `SURVEILLANCE` enter the

--- a/.claude/docs/adr/0003-cycle-timezone-via-url-param.md
+++ b/.claude/docs/adr/0003-cycle-timezone-via-url-param.md
@@ -1,0 +1,44 @@
+# Carry the Collection Cycle timezone through the review URL
+
+The review detail page (`/review/[siteId]`) needs a Collection Cycle's
+**Timezone** to render Session `collectionDate`s in the region where collection
+happened. We carry it as a `timezone` query param on the link built in
+`review-site-leaf-rows.tsx`, read it in `page.tsx`, and pass it down as a prop —
+the same channel already used for `startDate`, `endDate`, `collectionCycleId`,
+and `displayName`. We do **not** re-fetch cycles to resolve it.
+
+## Status
+
+accepted
+
+## Context
+
+A review workspace is scoped to one Site + one Cycle (or one month), so exactly
+one timezone is ever in play — see the **Timezone** entry in CONTEXT.md. The
+value is already loaded on the cycle object (`cycle.timezone`) at link-build
+time. Timezone is **display-only**: cycle membership is a backend instant
+comparison and is timezone-independent, so the worst failure mode here is a date
+_rendered_ off by a day, never a Session bucketed into the wrong Cycle.
+
+## Considered Options
+
+- **URL param (chosen).** Zero extra fetch; identical to how all other
+  detail-page context already flows. The cycle's denormalized timezone is fixed
+  at generation and never changes, so the snapshot can't go stale. Weakness: a
+  hand-edited or stripped URL omits the param and falls back to UTC display —
+  already the documented behavior for a null timezone.
+- **Re-fetch all cycles client-side + `Map<cycleId, timezone>` (the prior
+  approach).** Rejected: a redundant network round-trip on every workspace, and
+  the Map models a multiplicity of timezones that cannot occur (one per
+  workspace). The backend has no get-single-cycle endpoint, so resolving from
+  the id alone forces a full-list fetch.
+- **Derive server-side in `page.tsx`, pass as prop.** Rejected: reintroduces the
+  list fetch (now needing `programId` server-side) to guarantee "freshness" of a
+  value that never changes and is already in hand at link-build time.
+
+## Consequences
+
+The timezone is available to all three review workspaces (metadata, image,
+certification) as one prop without any of them fetching cycles. Anyone building
+a link into the review detail page must include the `timezone` param; omitting
+it degrades to UTC display, not an error.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "postinstall": "patch-package"
     },
     "dependencies": {
+        "@date-fns/tz": "^1.5.0",
         "@hookform/resolvers": "^5.2.1",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-aspect-ratio": "^1.1.7",

--- a/src/api/collection-cycle/validation/collection-cycle-schema.ts
+++ b/src/api/collection-cycle/validation/collection-cycle-schema.ts
@@ -8,6 +8,7 @@ export const collectionCycleSchema = z.object({
     cycleNumber: z.number(),
     startDate: z.number(),
     endDate: z.number(),
+    timezone: z.string().nullable(),
     createdAt: z.number(),
     updatedAt: z.number(),
     collectionSchedule: collectionScheduleSchema.optional(),

--- a/src/app/(dashboard)/review/[siteId]/page.tsx
+++ b/src/app/(dashboard)/review/[siteId]/page.tsx
@@ -21,6 +21,7 @@ interface ReviewSiteDetailPageProps {
         endDate?: string;
         displayName?: string;
         collectionCycleId?: string;
+        timezone?: string;
     }>;
 }
 
@@ -34,6 +35,7 @@ export default async function ReviewSiteDetailPage({
         endDate,
         displayName,
         collectionCycleId: collectionCycleIdParam,
+        timezone,
     } = await searchParams;
 
     const collectionCycleId: number | undefined =
@@ -106,6 +108,7 @@ export default async function ReviewSiteDetailPage({
                 startDate={startDate}
                 endDate={endDate}
                 collectionCycleId={collectionCycleId}
+                timezone={timezone}
                 siteName={displayName}
             />
         </HydrationBoundary>

--- a/src/features/review/site-details/certification/components/certification-workspace.tsx
+++ b/src/features/review/site-details/certification/components/certification-workspace.tsx
@@ -18,6 +18,7 @@ interface CertificationWorkspaceProps {
     startDate?: string;
     endDate?: string;
     collectionCycleId?: number;
+    timezone?: string;
     onGoToPreviousStep: () => void;
 }
 

--- a/src/features/review/site-details/components/review-site-details-page-client.tsx
+++ b/src/features/review/site-details/components/review-site-details-page-client.tsx
@@ -21,6 +21,7 @@ interface ReviewSiteDetailsPageClientProps {
     startDate?: string;
     endDate?: string;
     collectionCycleId?: number;
+    timezone?: string;
     siteName?: string;
 }
 
@@ -29,6 +30,7 @@ export default function ReviewSiteDetailsPageClient({
     startDate,
     endDate,
     collectionCycleId,
+    timezone,
     siteName,
 }: ReviewSiteDetailsPageClientProps) {
     const [currentStepIndex, setCurrentStepIndex] = useState(0);
@@ -66,6 +68,7 @@ export default function ReviewSiteDetailsPageClient({
                                 startDate={startDate}
                                 endDate={endDate}
                                 collectionCycleId={collectionCycleId}
+                                timezone={timezone}
                                 onGoToNextStep={goToNextStep}
                             />
                         )}
@@ -75,6 +78,7 @@ export default function ReviewSiteDetailsPageClient({
                                 startDate={startDate}
                                 endDate={endDate}
                                 collectionCycleId={collectionCycleId}
+                                timezone={timezone}
                                 onGoToPreviousStep={goToPreviousStep}
                                 onGoToNextStep={goToNextStep}
                             />
@@ -85,6 +89,7 @@ export default function ReviewSiteDetailsPageClient({
                                 startDate={startDate}
                                 endDate={endDate}
                                 collectionCycleId={collectionCycleId}
+                                timezone={timezone}
                                 onGoToPreviousStep={goToPreviousStep}
                             />
                         )}

--- a/src/features/review/site-details/image-review/components/image-review-workspace.tsx
+++ b/src/features/review/site-details/image-review/components/image-review-workspace.tsx
@@ -16,6 +16,7 @@ interface ImageReviewWorkspaceProps {
     startDate?: string;
     endDate?: string;
     collectionCycleId?: number;
+    timezone?: string;
     onGoToPreviousStep: () => void;
     onGoToNextStep: () => void;
 }

--- a/src/features/review/site-details/metadata-review/components/metadata-review-table.tsx
+++ b/src/features/review/site-details/metadata-review/components/metadata-review-table.tsx
@@ -10,7 +10,7 @@ import {
     TableHeader,
     TableRow,
 } from '@/components/ui/table';
-import { format } from 'date-fns';
+import { formatDateInTimezone } from '@/utils/format-date-in-timezone';
 import { cn } from '@/utils/cn';
 import { CircleCheck, TriangleAlert } from 'lucide-react';
 import {
@@ -30,6 +30,7 @@ import {
 
 interface MetadataReviewTableProps {
     sessions: Session[];
+    timezoneByCycleId: Map<number, string | null>;
     metadataRows: MetadataRow[];
     sessionIdsWithoutSurveillanceForm: Set<number>;
     resolutionsByMetadataRowId: Map<string, string>;
@@ -42,6 +43,7 @@ interface MetadataReviewTableProps {
 
 export default function MetadataReviewTable({
     sessions,
+    timezoneByCycleId,
     metadataRows,
     sessionIdsWithoutSurveillanceForm,
     resolutionsByMetadataRowId,
@@ -79,8 +81,13 @@ export default function MetadataReviewTable({
                                 key={session.sessionId}
                                 className="border-border border"
                             >
-                                {format(
-                                    new Date(session.collectionDate),
+                                {formatDateInTimezone(
+                                    session.collectionDate,
+                                    session.collectionCycleId !== null
+                                        ? (timezoneByCycleId.get(
+                                              session.collectionCycleId,
+                                          ) ?? null)
+                                        : null,
                                     'MMM d, yyyy',
                                 )}
                                 {sessionIdsWithoutSurveillanceForm.has(

--- a/src/features/review/site-details/metadata-review/components/metadata-review-table.tsx
+++ b/src/features/review/site-details/metadata-review/components/metadata-review-table.tsx
@@ -30,7 +30,7 @@ import {
 
 interface MetadataReviewTableProps {
     sessions: Session[];
-    timezoneByCycleId: Map<number, string | null>;
+    timezone: string | null;
     metadataRows: MetadataRow[];
     sessionIdsWithoutSurveillanceForm: Set<number>;
     resolutionsByMetadataRowId: Map<string, string>;
@@ -43,7 +43,7 @@ interface MetadataReviewTableProps {
 
 export default function MetadataReviewTable({
     sessions,
-    timezoneByCycleId,
+    timezone,
     metadataRows,
     sessionIdsWithoutSurveillanceForm,
     resolutionsByMetadataRowId,
@@ -83,11 +83,7 @@ export default function MetadataReviewTable({
                             >
                                 {formatDateInTimezone(
                                     session.collectionDate,
-                                    session.collectionCycleId !== null
-                                        ? (timezoneByCycleId.get(
-                                              session.collectionCycleId,
-                                          ) ?? null)
-                                        : null,
+                                    timezone,
                                     'MMM d, yyyy',
                                 )}
                                 {sessionIdsWithoutSurveillanceForm.has(

--- a/src/features/review/site-details/metadata-review/components/metadata-review-workspace.tsx
+++ b/src/features/review/site-details/metadata-review/components/metadata-review-workspace.tsx
@@ -3,8 +3,6 @@
 import { useGetAllSessions } from '@/api/session/hooks/use-get-all-sessions';
 import { useResolveSessionConflicts } from '@/api/session/hooks/use-resolve-session-conflicts';
 import { useGetSurveillanceFormsBySessionIds } from '@/api/surveillance-form/hooks/use-get-surveillance-form-by-session-id';
-import { useGetUserPermissions } from '@/api/user/hooks/use-get-user-permissions';
-import { useGetCollectionCycles } from '@/api/collection-cycle/hooks/use-get-collection-cycles';
 import {
     applyConflictResolutions,
     buildMetadataRows,
@@ -22,6 +20,7 @@ interface MetadataReviewWorkspaceProps {
     startDate?: string;
     endDate?: string;
     collectionCycleId?: number;
+    timezone?: string;
     onGoToNextStep: () => void;
 }
 
@@ -30,6 +29,7 @@ export default function MetadataReviewWorkspace({
     startDate,
     endDate,
     collectionCycleId,
+    timezone,
     onGoToNextStep,
 }: MetadataReviewWorkspaceProps) {
     const {
@@ -60,31 +60,6 @@ export default function MetadataReviewWorkspace({
     const allSessionsForSite = getAllSessionsResult?.ok
         ? getAllSessionsResult.data.sessions
         : [];
-
-    const { data: getUserPermissionsResult } = useGetUserPermissions();
-    const programId = getUserPermissionsResult?.ok
-        ? getUserPermissionsResult.data.programId
-        : undefined;
-
-    const { data: getCollectionCyclesResult } = useGetCollectionCycles(
-        programId ?? 0,
-        { startDate: startDate ?? '', endDate: endDate ?? '' },
-        {
-            enabled:
-                programId !== undefined &&
-                startDate !== undefined &&
-                endDate !== undefined,
-        },
-    );
-
-    const timezoneByCycleId = new Map<number, string | null>(
-        getCollectionCyclesResult?.ok
-            ? getCollectionCyclesResult.data.collectionCycles.map(cycle => [
-                  cycle.id,
-                  cycle.timezone,
-              ])
-            : [],
-    );
 
     const allSurveillanceFormQueriesForSite =
         useGetSurveillanceFormsBySessionIds(
@@ -205,7 +180,7 @@ export default function MetadataReviewWorkspace({
 
             <MetadataReviewTable
                 sessions={allSessionsForSite}
-                timezoneByCycleId={timezoneByCycleId}
+                timezone={timezone ?? null}
                 metadataRows={metadataRows}
                 sessionIdsWithoutSurveillanceForm={
                     sessionIdsWithoutSurveillanceForm

--- a/src/features/review/site-details/metadata-review/components/metadata-review-workspace.tsx
+++ b/src/features/review/site-details/metadata-review/components/metadata-review-workspace.tsx
@@ -3,6 +3,8 @@
 import { useGetAllSessions } from '@/api/session/hooks/use-get-all-sessions';
 import { useResolveSessionConflicts } from '@/api/session/hooks/use-resolve-session-conflicts';
 import { useGetSurveillanceFormsBySessionIds } from '@/api/surveillance-form/hooks/use-get-surveillance-form-by-session-id';
+import { useGetUserPermissions } from '@/api/user/hooks/use-get-user-permissions';
+import { useGetCollectionCycles } from '@/api/collection-cycle/hooks/use-get-collection-cycles';
 import {
     applyConflictResolutions,
     buildMetadataRows,
@@ -58,6 +60,31 @@ export default function MetadataReviewWorkspace({
     const allSessionsForSite = getAllSessionsResult?.ok
         ? getAllSessionsResult.data.sessions
         : [];
+
+    const { data: getUserPermissionsResult } = useGetUserPermissions();
+    const programId = getUserPermissionsResult?.ok
+        ? getUserPermissionsResult.data.programId
+        : undefined;
+
+    const { data: getCollectionCyclesResult } = useGetCollectionCycles(
+        programId ?? 0,
+        { startDate: startDate ?? '', endDate: endDate ?? '' },
+        {
+            enabled:
+                programId !== undefined &&
+                startDate !== undefined &&
+                endDate !== undefined,
+        },
+    );
+
+    const timezoneByCycleId = new Map<number, string | null>(
+        getCollectionCyclesResult?.ok
+            ? getCollectionCyclesResult.data.collectionCycles.map(cycle => [
+                  cycle.id,
+                  cycle.timezone,
+              ])
+            : [],
+    );
 
     const allSurveillanceFormQueriesForSite =
         useGetSurveillanceFormsBySessionIds(
@@ -178,6 +205,7 @@ export default function MetadataReviewWorkspace({
 
             <MetadataReviewTable
                 sessions={allSessionsForSite}
+                timezoneByCycleId={timezoneByCycleId}
                 metadataRows={metadataRows}
                 sessionIdsWithoutSurveillanceForm={
                     sessionIdsWithoutSurveillanceForm

--- a/src/features/review/sites-list/components/sites/review-site-hierarchy.tsx
+++ b/src/features/review/sites-list/components/sites/review-site-hierarchy.tsx
@@ -28,6 +28,7 @@ interface ReviewSiteHierarchyProps {
     startDate: string;
     endDate: string;
     collectionCycleId?: number;
+    timezone?: string | null;
     sessionCountsBySiteId: Map<number, ReviewSiteSessionSummary>;
     expandedSitePaths: Set<string>;
     onTogglePath: (path: string, descendantPaths: string[]) => void;
@@ -39,6 +40,7 @@ export default function ReviewSiteHierarchy({
     startDate,
     endDate,
     collectionCycleId,
+    timezone,
     sessionCountsBySiteId,
     expandedSitePaths,
     onTogglePath,
@@ -58,6 +60,7 @@ export default function ReviewSiteHierarchy({
                     startDate={startDate}
                     endDate={endDate}
                     collectionCycleId={collectionCycleId}
+                    timezone={timezone}
                 />
             )}
             renderGroupContent={sitesInGroup => {

--- a/src/features/review/sites-list/components/sites/review-site-leaf-rows.tsx
+++ b/src/features/review/sites-list/components/sites/review-site-leaf-rows.tsx
@@ -23,6 +23,7 @@ interface ReviewSiteLeafRowsProps {
     startDate: string;
     endDate: string;
     collectionCycleId?: number;
+    timezone?: string | null;
 }
 
 function buildReviewHref(
@@ -31,6 +32,7 @@ function buildReviewHref(
     endDate: string,
     displayName: string,
     collectionCycleId?: number,
+    timezone?: string | null,
 ) {
     const queryParams = new URLSearchParams({
         startDate,
@@ -39,6 +41,9 @@ function buildReviewHref(
     });
     if (collectionCycleId !== undefined) {
         queryParams.set('collectionCycleId', String(collectionCycleId));
+    }
+    if (timezone !== undefined && timezone !== null) {
+        queryParams.set('timezone', timezone);
     }
     return `/review/${site.siteId}?${queryParams.toString()}`;
 }
@@ -50,6 +55,7 @@ export default function ReviewSiteLeafRows({
     startDate,
     endDate,
     collectionCycleId,
+    timezone,
 }: ReviewSiteLeafRowsProps) {
     const t = useTranslations('ReviewSitesList');
     if (sites.length === 0) return null;
@@ -133,6 +139,7 @@ export default function ReviewSiteLeafRows({
                                 endDate,
                                 getDisplayName(site),
                                 collectionCycleId,
+                                timezone,
                             )}
                             className={rowClassName}
                         >

--- a/src/features/review/sites-list/components/sites/review-site-leaf-rows.tsx
+++ b/src/features/review/sites-list/components/sites/review-site-leaf-rows.tsx
@@ -42,7 +42,7 @@ function buildReviewHref(
     if (collectionCycleId !== undefined) {
         queryParams.set('collectionCycleId', String(collectionCycleId));
     }
-    if (timezone !== undefined && timezone !== null) {
+    if (timezone != null) {
         queryParams.set('timezone', timezone);
     }
     return `/review/${site.siteId}?${queryParams.toString()}`;

--- a/src/features/review/sites-list/components/sites/review-sites-list.tsx
+++ b/src/features/review/sites-list/components/sites/review-sites-list.tsx
@@ -216,6 +216,7 @@ export default function ReviewSitesList({
                                     startDate={segmentStartDate}
                                     endDate={segmentEndDate}
                                     collectionCycleId={cycleSegment.cycle.id}
+                                    timezone={cycleSegment.cycle.timezone}
                                     sessionCountsBySiteId={
                                         cycleSegment.sessionSummaryBySiteId
                                     }

--- a/src/features/review/sites-list/components/sites/review-sites-list.tsx
+++ b/src/features/review/sites-list/components/sites/review-sites-list.tsx
@@ -20,6 +20,7 @@ import type { CollectionCycle } from '@/api/collection-cycle/validation/collecti
 import { buildCollectionCycleSegments } from '@/features/review/sites-list/utils/build-collection-cycle-segments';
 import { accumulateSessionSummary } from '@/features/review/sites-list/utils/accumulate-session-summary';
 import { formatCollectionCycleLabel } from '@/features/review/sites-list/utils/format-collection-cycle-label';
+import { formatDateInTimezone } from '@/utils/format-date-in-timezone';
 import ReviewSiteHierarchy from '@/features/review/sites-list/components/sites/review-site-hierarchy';
 import { type ReviewSiteSessionSummary } from '@/features/review/utils/review-site-session-summary';
 import { useTranslations } from 'next-intl';
@@ -73,8 +74,9 @@ export default function ReviewSitesList({
         if (!getAllSessionsResult?.ok) return map;
 
         for (const session of getAllSessionsResult.data.sessions) {
-            const monthKey = format(
-                new Date(session.collectionDate),
+            const monthKey = formatDateInTimezone(
+                session.collectionDate,
+                'UTC',
                 'yyyy-MM',
             );
             if (!map.has(monthKey)) map.set(monthKey, new Map());
@@ -173,14 +175,22 @@ export default function ReviewSitesList({
                     const key = String(cycleSegment.cycle.id);
                     const isCollapsed = collapsedSegments.has(key);
 
-                    const segmentStartDate = format(
-                        new Date(cycleSegment.cycle.startDate),
-                        'yyyy-MM-dd',
-                    );
-                    const segmentEndDate = format(
-                        new Date(cycleSegment.cycle.endDate),
-                        'yyyy-MM-dd',
-                    );
+                    const segmentStartDate =
+                        cycleSegment.cycle !== null
+                            ? formatDateInTimezone(
+                                  cycleSegment.cycle.startDate,
+                                  cycleSegment.cycle.timezone,
+                                  'yyyy-MM-dd',
+                              )
+                            : startDate;
+                    const segmentEndDate =
+                        cycleSegment.cycle !== null
+                            ? formatDateInTimezone(
+                                  cycleSegment.cycle.endDate,
+                                  cycleSegment.cycle.timezone,
+                                  'yyyy-MM-dd',
+                              )
+                            : endDate;
 
                     const label = formatCollectionCycleLabel(
                         cycleSegment.cycle,

--- a/src/features/review/sites-list/utils/format-collection-cycle-label.ts
+++ b/src/features/review/sites-list/utils/format-collection-cycle-label.ts
@@ -1,11 +1,19 @@
 import type { CollectionCycle } from '@/api/collection-cycle/validation/collection-cycle-schema';
-import { format } from 'date-fns';
+import { formatDateInTimezone } from '@/utils/format-date-in-timezone';
 
 export function formatCollectionCycleLabel(
     cycle: CollectionCycle,
     t: (key: string, values?: Record<string, string | number>) => string,
 ): string {
-    const start = format(new Date(cycle.startDate), 'MMM d');
-    const end = format(new Date(cycle.endDate), 'MMM d, yyyy');
+    const start = formatDateInTimezone(
+        cycle.startDate,
+        cycle.timezone,
+        'MMM d',
+    );
+    const end = formatDateInTimezone(
+        cycle.endDate,
+        cycle.timezone,
+        'MMM d, yyyy',
+    );
     return t('cycleLabel', { cycleNumber: cycle.cycleNumber, start, end });
 }

--- a/src/utils/format-date-in-timezone.ts
+++ b/src/utils/format-date-in-timezone.ts
@@ -1,0 +1,10 @@
+import { TZDate } from '@date-fns/tz';
+import { format } from 'date-fns';
+
+export function formatDateInTimezone(
+    timestampMs: number,
+    timezone: string | null,
+    formatPattern: string,
+): string {
+    return format(new TZDate(timestampMs, timezone ?? 'UTC'), formatPattern);
+}

--- a/src/utils/format-date-in-timezone.ts
+++ b/src/utils/format-date-in-timezone.ts
@@ -1,10 +1,23 @@
 import { TZDate } from '@date-fns/tz';
 import { format } from 'date-fns';
 
+function getValidTimezone(timezone: string | null): string {
+    if (!timezone) return 'UTC';
+    try {
+        Intl.DateTimeFormat('en-US', { timeZone: timezone });
+        return timezone;
+    } catch {
+        return 'UTC';
+    }
+}
+
 export function formatDateInTimezone(
     timestampMs: number,
     timezone: string | null,
     formatPattern: string,
 ): string {
-    return format(new TZDate(timestampMs, timezone ?? 'UTC'), formatPattern);
+    return format(
+        new TZDate(timestampMs, getValidTimezone(timezone)),
+        formatPattern,
+    );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,6 +46,11 @@
   resolved "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz"
   integrity sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==
 
+"@date-fns/tz@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@date-fns/tz/-/tz-1.5.0.tgz#e9e79b7583f0b1322c53db884a0112551095e3f3"
+  integrity sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==
+
 "@emnapi/core@^1.4.3", "@emnapi/core@^1.7.1":
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.2.tgz#3870265ecffc7352d01ead62d8d83d8358a2d034"


### PR DESCRIPTION
## VCV-237 — Carry Collection Cycle timezone through the review URL

### Summary
The metadata review table renders each Session's collection date in the **timezone of the region where collection happened** (denormalized onto the Collection Cycle), never the reviewer's browser timezone. Previously the metadata workspace obtained that timezone by re-fetching **every** Collection Cycle for the program to build a `cycleId → timezone` map. Since a review workspace is scoped to one Site + one Cycle (or one month), exactly one timezone is ever in play — so this swaps the redundant fetch for a single `timezone` value carried on the review-detail URL, the same channel that already carries `startDate`, `endDate`, `collectionCycleId`, and `displayName`.

### Changes
- **Link builder** (`review-site-leaf-rows`): appends a `timezone` query param when a non-null value exists; threaded down through `review-site-hierarchy` and `review-sites-list`. Cycle mode passes `cycle.timezone`; month mode passes nothing (param omitted → UTC).
- **Detail page** (`page.tsx` → `review-site-details-page-client`): reads the optional `timezone` searchParam and forwards it as a prop to all three review workspaces (metadata, image, certification).
- **Metadata workspace**: removed the `useGetCollectionCycles` query, the `useGetUserPermissions`/`programId` derivation, and the `cycleId → timezone` map; now passes a single `timezone` down.
- **Metadata table**: replaced the `timezoneByCycleId` map prop with a single `timezone: string | null`, used directly in `formatDateInTimezone`.
- **Robustness guard** (`getValidTimezone` in `format-date-in-timezone`): coerces a malformed (non-IANA) timezone to UTC instead of throwing. Protects every caller (sites list + detail page), not just the new URL path.

### Behavior / fallback
- Valid IANA zone → dates render in that zone.
- `timezone` omitted, empty, or `null` → UTC display (matches documented null-timezone behavior; a stripped/shared link is safe, never an error).
- Malformed zone string → UTC display (previously crashed the page — see note below).
- Cycle membership is unaffected: it stays backend-owned (instant comparison), timezone-independent. Timezone is display-only.

### Testing
No automated tests added — this is prop/URL plumbing on top of the already-exercised `formatDateInTimezone` helper, typed end to end. Verified manually by driving the running app:
- Cycle-mode site → review link carries `timezone=Africa/Kampala`; detail URL preserves it.
- Metadata table dates render in the cycle's zone — confirmed by a 25-hour timezone swing flipping the displayed day (May 27 ↔ May 26), proving the value is actually consumed.
- **Zero `collection-cycles` requests** fire on the detail page across every load (the removed fetch).
- Omitted / empty / malformed `timezone` params all fall back to UTC with no error.

### Note: backend follow-up (out of scope)
The root cause of the malformed-zone crash is that the backend stores the timezone string **unvalidated** — `POST /collection-schedules` accepts any string (verified in `vectorcam-api`, no IANA check anywhere). The frontend guard added here is defense-in-depth for the user-editable URL vector this PR introduces; the durable fix is IANA validation on the backend write path, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
