### PR TITLE
VCV-240: switch no-location-selection page from skeleton to static display

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -100,6 +100,11 @@
         "collector": "Collector",
         "session": "session"
     },
+    "Review": {
+        "review": "Review",
+        "reviewDescription": "Review submitted session data by location",
+        "selectALocation": "Select a location to view data."
+    },
     "ReviewSitesList": {
         "needsReview": "Needs Review",
         "inReview": "In Review",

--- a/src/features/operations/components/operations-page-client.tsx
+++ b/src/features/operations/components/operations-page-client.tsx
@@ -12,7 +12,6 @@ import { Separator } from '@/components/ui/separator';
 import OperationsHeader from '@/features/operations/components/layout/operations-header';
 import OperationsAiPerformance from '@/features/operations/ai-performance/components/operations-ai-performance';
 import OperationsGeographicalSummary from '@/features/operations/geographical-summary/components/operations-geographical-summary';
-import { SkeletonList } from '@/components/ui/skeleton-list';
 import ExportDialog from '@/features/operations/components/export/export-dialog';
 import OperationsSpecimenComposition from '@/features/operations/specimen-composition/components/operations-specimen-composition';
 import OperationsFieldUserCompliance from '@/features/operations/field-user-compliance/components/operations-field-user-compliance';
@@ -48,7 +47,7 @@ export type OperationsTab = (typeof OPERATIONS_TABS)[number]['value'];
 
 export default function OperationsPageClient() {
     const t = useTranslations('Operations');
-    const tCommmon = useTranslations('Common');
+    const tCommon = useTranslations('Common');
     const [activeTab, setActiveTab] = useLocalStorage<OperationsTab>(
         StorageKeys.operations.activeTab,
         'geographical-summary',
@@ -101,7 +100,7 @@ export default function OperationsPageClient() {
                 icon={Microscope}
             >
                 <p className="text-muted-foreground text-sm">
-                    {tCommmon('loading')}
+                    {tCommon('loading')}
                 </p>
             </PageShell>
         );
@@ -154,14 +153,11 @@ export default function OperationsPageClient() {
                     <Separator />
 
                     {!selectedSiteIdsParam ? (
-                        <div className="relative">
-                            <SkeletonList count={5} height="xl" width="full" />
-                            <div className="absolute inset-0 flex flex-col items-center justify-center text-center">
-                                <Microscope className="text-muted-foreground/50 mb-4 h-12 w-12" />
-                                <p className="text-muted-foreground text-sm">
-                                    {t('selectALocation')}
-                                </p>
-                            </div>
+                        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-16 text-center">
+                            <Microscope className="text-muted-foreground/50 mb-4 h-12 w-12" />
+                            <p className="text-muted-foreground text-sm">
+                                {t('selectALocation')}
+                            </p>
                         </div>
                     ) : (
                         <Fragment>

--- a/src/features/review/sites-list/components/review-sites-list-page-client.tsx
+++ b/src/features/review/sites-list/components/review-sites-list-page-client.tsx
@@ -16,6 +16,7 @@ import { StorageKeys } from '@/lib/storage-keys';
 import ReviewSitesListHeader from '@/features/review/sites-list/components/layout/review-sites-list-header';
 import ReviewSitesList from '@/features/review/sites-list/components/sites/review-sites-list';
 import ReviewDhis2Dashboard from '../../dhis2-sync/components/review-dhis2-dashboard';
+import { useTranslations } from 'next-intl';
 
 const REVIEW_TABS = [
     { value: 'sites-list', label: 'SITES LIST' },
@@ -25,6 +26,8 @@ const REVIEW_TABS = [
 export type ReviewTab = (typeof REVIEW_TABS)[number]['value'];
 
 export default function ReviewSitesListPageClient() {
+    const t = useTranslations('Review');
+    const tCommon = useTranslations('Common');
     const [activeTab, setActiveTab] = useLocalStorage<ReviewTab>(
         StorageKeys.review.activeTab,
         'sites-list',
@@ -116,11 +119,13 @@ export default function ReviewSitesListPageClient() {
     if (isGetUserPermissionsPending || !getUserPermissionsResult) {
         return (
             <PageShell
-                title="Review"
-                description="Review submitted session data by location"
+                title={t('review')}
+                description={t('reviewDescription')}
                 icon={ClipboardList}
             >
-                <p className="text-muted-foreground text-sm">Loading...</p>
+                <p className="text-muted-foreground text-sm">
+                    {tCommon('loading')}
+                </p>
             </PageShell>
         );
     }
@@ -128,8 +133,8 @@ export default function ReviewSitesListPageClient() {
     if (!getUserPermissionsResult.ok) {
         return (
             <PageShell
-                title="Review"
-                description="Review submitted session data by location"
+                title={t('review')}
+                description={t('reviewDescription')}
                 icon={ClipboardList}
             >
                 <p className="text-destructive text-sm">
@@ -141,8 +146,8 @@ export default function ReviewSitesListPageClient() {
 
     return (
         <PageShell
-            title="Review"
-            description="Review submitted session data by location"
+            title={t('review')}
+            description={t('reviewDescription')}
             icon={ClipboardList}
         >
             <Card className="border-border/50 bg-card/50 shadow-lg backdrop-blur-sm">
@@ -172,14 +177,11 @@ export default function ReviewSitesListPageClient() {
                     <Separator />
 
                     {!locationQueryParam ? (
-                        <div className="relative">
-                            <SkeletonList count={5} height="xl" width="full" />
-                            <div className="absolute inset-0 flex flex-col items-center justify-center text-center">
-                                <ClipboardList className="text-muted-foreground/50 mb-4 h-12 w-12" />
-                                <p className="text-muted-foreground text-sm">
-                                    Select a location to view data.
-                                </p>
-                            </div>
+                        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-16 text-center">
+                            <ClipboardList className="text-muted-foreground/50 mb-4 h-12 w-12" />
+                            <p className="text-muted-foreground text-sm">
+                                {t('selectALocation')}
+                            </p>
                         </div>
                     ) : activeTab === 'sites-list' ? (
                         isGetCollectionCyclesPending ? (


### PR DESCRIPTION
* Switched no-location state for operations and review pages to a dotted rectangle outline with the icon and 'select a location' message from the original skeletons
* Added strings to en.json for review page
* Fixed a typo in operations-page-client, tCommmon -> tCommon