### PR TITLE
VCV-263: AI performance tab should have a no-data appearance for the confusion matrices

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -79,6 +79,7 @@
     "OperationsAIPerformance": {
         "accuracy": "Accuracy",
         "correctOf": "{numCorrect} correct of {total} {category} comparisons",
+        "noConfusionMatrixData": "No verified {category} comparisons in this date range.",
         "perLabelMetrics": "Per-Label Metrics",
         "label": "Label",
         "sensitivity": "Sensitivity",

--- a/messages/en.json
+++ b/messages/en.json
@@ -79,7 +79,7 @@
     "OperationsAIPerformance": {
         "accuracy": "Accuracy",
         "correctOf": "{numCorrect} correct of {total} {category} comparisons",
-        "noConfusionMatrixData": "No verified {category} comparisons in this date range.",
+        "noConfusionMatrixData": "No verified {category} comparisons in this date range; there are no annotations to compare with VectorCam's predictions.",
         "perLabelMetrics": "Per-Label Metrics",
         "label": "Label",
         "sensitivity": "Sensitivity",

--- a/src/features/operations/ai-performance/components/specimen-confusion-matrix.tsx
+++ b/src/features/operations/ai-performance/components/specimen-confusion-matrix.tsx
@@ -89,6 +89,20 @@ export default function SpecimenConfusionMatrix({
         0,
     );
 
+    if (totalSpecimensInMatrix === 0) {
+        return (
+            <Card className="gap-0 lg:col-span-2">
+                <CardContent className="space-y-6">
+                    <p className="text-muted-foreground w-full justify-center text-sm">
+                        {t('noConfusionMatrixData', {
+                            category: classificationCategory,
+                        })}
+                    </p>
+                </CardContent>
+            </Card>
+        );
+    }
+
     const totalCorrectPredictions = classLabels.reduce(
         (totalSpecimens, classLabel) =>
             totalSpecimens + getSpecimenCountForCell(classLabel, classLabel),


### PR DESCRIPTION
* Adjusted specimen-confusion-matrix to return a card with a 'no verified comparisons' message if totalSpecimensInMatrix is 0 to avoid having an empty confusion matrix/empty sensitivity and specificity table