### PR TITLE
VCV-248: Add a percent-confidence to AI prediction

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -156,7 +156,8 @@
         "modelPredictions": "Model Predictions",
         "species": "Species",
         "sex": "Sex",
-        "abdomenStatus": "Abdomen Status"
+        "abdomenStatus": "Abdomen Status",
+        "modelConfidence": "Model Confidence"
     },
     "ReviewCertification": {
         "title": "Certify Site",

--- a/src/features/review/workspace/image/components/confidence-prediction-row.tsx
+++ b/src/features/review/workspace/image/components/confidence-prediction-row.tsx
@@ -1,0 +1,45 @@
+import { cn } from '@/utils/cn';
+import { AlertTriangle } from 'lucide-react';
+import { Fragment } from 'react/jsx-runtime';
+
+interface ConfidencePredictionRowProps {
+    category: string;
+    label: string | null | undefined;
+    confidencePercentage: number | null;
+    isLoading: boolean;
+}
+
+const MODEL_CONFIDENCE_THRESHOLD = 75;
+
+export default function ConfidencePredictionRow({
+    category,
+    label,
+    confidencePercentage,
+    isLoading,
+}: ConfidencePredictionRowProps) {
+    const isLowConfidence =
+        !isLoading &&
+        confidencePercentage != null &&
+        confidencePercentage < MODEL_CONFIDENCE_THRESHOLD;
+
+    return (
+        <Fragment>
+            <dt className="text-muted-foreground">{category}</dt>
+            <dd
+                className={cn(
+                    isLowConfidence && 'text-destructive',
+                    'flex gap-x-4',
+                )}
+            >
+                <span className="w-10 shrink-0">
+                    {!isLoading && label ? `${confidencePercentage}%` : '—'}
+                </span>
+                <span className="w-4 shrink-0">
+                    {isLowConfidence && (
+                        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                    )}
+                </span>
+            </dd>
+        </Fragment>
+    );
+}

--- a/src/features/review/workspace/image/components/image-review-details.tsx
+++ b/src/features/review/workspace/image/components/image-review-details.tsx
@@ -50,7 +50,12 @@ export default function ImageReviewDetails({
           )
         : '—';
 
-    function getMaxConfidencePercentage(logits: number[]): number {
+    function getMaxConfidencePercentage(
+        logits: number[] | undefined,
+    ): number | null {
+        if (!logits || logits.length === 0) {
+            return null;
+        }
         const exps = logits.map(x => Math.exp(x));
         const sumExps = exps.reduce((a, b) => a + b, 0);
         return Math.round(Math.max(...exps.map(x => x / sumExps)) * 1000) / 10;
@@ -58,19 +63,19 @@ export default function ImageReviewDetails({
 
     const modelConfidencePercentages = {
         species: currentImage?.species
-            ? (getMaxConfidencePercentage(
-                  currentImage!.inferenceResult!.speciesLogits,
-              ) ?? null)
+            ? getMaxConfidencePercentage(
+                  currentImage?.inferenceResult?.speciesLogits,
+              )
             : null,
         sex: currentImage?.sex
-            ? (getMaxConfidencePercentage(
-                  currentImage!.inferenceResult!.sexLogits,
-              ) ?? null)
+            ? getMaxConfidencePercentage(
+                  currentImage?.inferenceResult?.sexLogits,
+              )
             : null,
         abdomenStatus: currentImage?.abdomenStatus
-            ? (getMaxConfidencePercentage(
-                  currentImage!.inferenceResult!.abdomenStatusLogits,
-              ) ?? null)
+            ? getMaxConfidencePercentage(
+                  currentImage?.inferenceResult?.abdomenStatusLogits,
+              )
             : null,
     };
 

--- a/src/features/review/workspace/image/components/image-review-details.tsx
+++ b/src/features/review/workspace/image/components/image-review-details.tsx
@@ -19,6 +19,7 @@ export default function ImageReviewDetails({
     timezone,
 }: ImageReviewDetailsProps) {
     const t = useTranslations('ReviewImage');
+    console.log(specimen);
 
     const totalImagesUploaded = specimen.images?.length ?? 0;
     const expectedImagesCount = specimen.expectedImages;
@@ -48,6 +49,12 @@ export default function ImageReviewDetails({
               'MMM d, yyyy h:mm a',
           )
         : '—';
+
+    function getMaxConfidencePercentage(logits: number[]): number {
+        const exps = logits.map(x => Math.exp(x));
+        const sumExps = exps.reduce((a, b) => a + b, 0);
+        return Math.round(Math.max(...exps.map(x => x / sumExps)) * 1000) / 10;
+    }
 
     return (
         <div className="space-y-4">
@@ -124,6 +131,43 @@ export default function ImageReviewDetails({
                         {t('abdomenStatus')}
                     </dt>
                     <dd>{currentImage?.abdomenStatus ?? '—'}</dd>
+                </dl>
+            </div>
+
+            <Separator />
+
+            <div className="space-y-3">
+                <p className="text-sm font-semibold">{t('modelConfidence')}</p>
+                <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-2 text-sm">
+                    <dt className="text-muted-foreground">{t('species')}</dt>
+                    <dd>
+                        {currentImage?.species
+                            ? (getMaxConfidencePercentage(
+                                  currentImage!.inferenceResult!.speciesLogits,
+                              ) ?? null) + '%'
+                            : '—'}
+                    </dd>
+
+                    <dt className="text-muted-foreground">{t('sex')}</dt>
+                    <dd>
+                        {currentImage?.sex
+                            ? (getMaxConfidencePercentage(
+                                  currentImage!.inferenceResult!.sexLogits,
+                              ) ?? null) + '%'
+                            : '—'}
+                    </dd>
+
+                    <dt className="text-muted-foreground">
+                        {t('abdomenStatus')}
+                    </dt>
+                    <dd>
+                        {currentImage?.abdomenStatus
+                            ? (getMaxConfidencePercentage(
+                                  currentImage!.inferenceResult!
+                                      .abdomenStatusLogits,
+                              ) ?? null) + '%'
+                            : '—'}
+                    </dd>
                 </dl>
             </div>
         </div>

--- a/src/features/review/workspace/image/components/image-review-details.tsx
+++ b/src/features/review/workspace/image/components/image-review-details.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/utils/cn';
 import { formatDateInTimezone } from '@/utils/format-date-in-timezone';
 import { AlertCircle } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import ConfidencePredictionRow from '@/features/review/workspace/image/components/confidence-prediction-row';
 
 interface ImageReviewDetailsProps {
     specimen: Specimen;
@@ -19,7 +20,6 @@ export default function ImageReviewDetails({
     timezone,
 }: ImageReviewDetailsProps) {
     const t = useTranslations('ReviewImage');
-    console.log(specimen);
 
     const totalImagesUploaded = specimen.images?.length ?? 0;
     const expectedImagesCount = specimen.expectedImages;
@@ -55,6 +55,26 @@ export default function ImageReviewDetails({
         const sumExps = exps.reduce((a, b) => a + b, 0);
         return Math.round(Math.max(...exps.map(x => x / sumExps)) * 1000) / 10;
     }
+
+    const modelConfidencePercentages = {
+        species: currentImage?.species
+            ? (getMaxConfidencePercentage(
+                  currentImage!.inferenceResult!.speciesLogits,
+              ) ?? null)
+            : null,
+        sex: currentImage?.sex
+            ? (getMaxConfidencePercentage(
+                  currentImage!.inferenceResult!.sexLogits,
+              ) ?? null)
+            : null,
+        abdomenStatus: currentImage?.abdomenStatus
+            ? (getMaxConfidencePercentage(
+                  currentImage!.inferenceResult!.abdomenStatusLogits,
+              ) ?? null)
+            : null,
+    };
+
+    const isLoading = !specimen || !currentImage;
 
     return (
         <div className="space-y-4">
@@ -139,35 +159,30 @@ export default function ImageReviewDetails({
             <div className="space-y-3">
                 <p className="text-sm font-semibold">{t('modelConfidence')}</p>
                 <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-2 text-sm">
-                    <dt className="text-muted-foreground">{t('species')}</dt>
-                    <dd>
-                        {currentImage?.species
-                            ? (getMaxConfidencePercentage(
-                                  currentImage!.inferenceResult!.speciesLogits,
-                              ) ?? null) + '%'
-                            : '—'}
-                    </dd>
+                    <ConfidencePredictionRow
+                        category={t('species')}
+                        label={currentImage?.species}
+                        confidencePercentage={
+                            modelConfidencePercentages.species
+                        }
+                        isLoading={isLoading}
+                    />
 
-                    <dt className="text-muted-foreground">{t('sex')}</dt>
-                    <dd>
-                        {currentImage?.sex
-                            ? (getMaxConfidencePercentage(
-                                  currentImage!.inferenceResult!.sexLogits,
-                              ) ?? null) + '%'
-                            : '—'}
-                    </dd>
+                    <ConfidencePredictionRow
+                        category={t('sex')}
+                        label={currentImage?.sex}
+                        confidencePercentage={modelConfidencePercentages.sex}
+                        isLoading={isLoading}
+                    />
 
-                    <dt className="text-muted-foreground">
-                        {t('abdomenStatus')}
-                    </dt>
-                    <dd>
-                        {currentImage?.abdomenStatus
-                            ? (getMaxConfidencePercentage(
-                                  currentImage!.inferenceResult!
-                                      .abdomenStatusLogits,
-                              ) ?? null) + '%'
-                            : '—'}
-                    </dd>
+                    <ConfidencePredictionRow
+                        category={t('abdomenStatus')}
+                        label={currentImage?.abdomenStatus}
+                        confidencePercentage={
+                            modelConfidencePercentages.abdomenStatus
+                        }
+                        isLoading={isLoading}
+                    />
                 </dl>
             </div>
         </div>


### PR DESCRIPTION
* Added an additional section in the image review section for model confidence
* While loading or if there is no prediction for a category, the percent confidence will show up as a dash 
* If the percent confidence is below 75%, it will be red and have a triangle alert next to it 