### PR TITLE
VCV-292: Give nominatimSearch country param so markers are more accurate

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
         "embla-carousel-react": "^8.6.0",
+        "i18n-iso-countries": "^7.14.0",
         "leaflet": "^1.9.4",
         "lucide-react": "^1.8.0",
         "next": "^16.1.6",

--- a/src/api/geocode/get-geocode.ts
+++ b/src/api/geocode/get-geocode.ts
@@ -1,5 +1,7 @@
 import 'server-only';
 
+import countries from 'i18n-iso-countries';
+import enLocale from 'i18n-iso-countries/langs/en.json';
 import { z } from 'zod';
 import type { NetworkError } from '@/lib/network/network-error';
 import { err, ok, type Result } from '@/lib/result/result';
@@ -10,6 +12,8 @@ import {
     type GetGeocodeResponseBody,
 } from './validation/get-geocode-schema';
 
+countries.registerLocale(enLocale);
+
 const nominatimResponseSchema = z.array(
     z.object({ lat: z.string(), lon: z.string() }),
 );
@@ -19,6 +23,7 @@ const RATE_LIMIT_MS = 1100;
 
 async function nominatimSearch(
     searchQuery: string,
+    countryCode?: string,
 ): Promise<Result<GetGeocodeResponseBody | null, NetworkError>> {
     const timeSinceLastRequest = Date.now() - lastRequestTimestamp;
     const rateLimitDelay = Math.max(0, RATE_LIMIT_MS - timeSinceLastRequest);
@@ -26,7 +31,10 @@ async function nominatimSearch(
         await new Promise(resolve => setTimeout(resolve, rateLimitDelay));
     lastRequestTimestamp = Date.now();
 
-    const url = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(searchQuery)}&format=json&limit=1`;
+    const countryCodeParam = countryCode
+        ? `&countrycodes=${encodeURIComponent(countryCode)}`
+        : '';
+    const url = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(searchQuery)}&format=json&limit=1${countryCodeParam}`;
 
     const result = await safeApiCall(
         url,
@@ -79,9 +87,12 @@ export async function getGeocode(
     queryParams: GetGeocodeQueryParams,
 ): Promise<Result<GetGeocodeResponseBody, NetworkError>> {
     const fallbackQueries = buildFallbackQueries(queryParams.location);
+    const countryCode = queryParams.country
+        ? countries.getAlpha2Code(queryParams.country, 'en')
+        : undefined;
 
     for (const query of fallbackQueries) {
-        const result = await nominatimSearch(query);
+        const result = await nominatimSearch(query, countryCode);
         if (!result.ok) return result;
         if (result.data) return ok(result.data);
     }

--- a/src/api/geocode/validation/get-geocode-schema.ts
+++ b/src/api/geocode/validation/get-geocode-schema.ts
@@ -3,6 +3,7 @@ import { geocodeSchema } from './geocode-schema';
 
 export const getGeocodeQueryParamsSchema = z.object({
     location: z.string(),
+    country: z.string().optional(),
 });
 
 export const getGeocodeResponseSchema = geocodeSchema;

--- a/src/features/operations/geographical-summary/components/device-map.tsx
+++ b/src/features/operations/geographical-summary/components/device-map.tsx
@@ -10,6 +10,7 @@ import MarkerInfoPanel from '@/features/operations/geographical-summary/componen
 
 interface DeviceMapProps {
     markers: DeviceMarker[];
+    country: string;
     selectedLocations: string[];
     selectedMarkerId: string | null;
     onMarkerSelect: (id: string | null) => void;
@@ -17,6 +18,7 @@ interface DeviceMapProps {
 
 export default function DeviceMap({
     markers,
+    country,
     selectedLocations,
     selectedMarkerId,
     onMarkerSelect,
@@ -31,6 +33,7 @@ export default function DeviceMap({
     return (
         <GeocodedClusterMap
             markers={markers}
+            country={country}
             selectedLocations={selectedLocations}
             selectedMarkerId={selectedMarkerId}
             onMarkerSelect={onMarkerSelect}

--- a/src/features/operations/geographical-summary/components/device-view.tsx
+++ b/src/features/operations/geographical-summary/components/device-view.tsx
@@ -16,6 +16,7 @@ const DeviceMap = dynamic(() => import('./device-map'), { ssr: false });
 
 interface DeviceViewProps {
     programId: number;
+    country: string;
     siteIds: number[];
     selectedLocations: string[];
     descendantsOfSelectedLocations: Site[];
@@ -23,6 +24,7 @@ interface DeviceViewProps {
 
 export default function DeviceView({
     programId,
+    country,
     siteIds,
     selectedLocations,
     descendantsOfSelectedLocations,
@@ -120,6 +122,7 @@ export default function DeviceView({
                 <CardContent className="relative h-125 p-0">
                     <DeviceMap
                         markers={deviceMarkers}
+                        country={country}
                         selectedLocations={selectedLocations}
                         selectedMarkerId={selectedMarkerId}
                         onMarkerSelect={setSelectedMarkerId}

--- a/src/features/operations/geographical-summary/components/geocoded-cluster-map.tsx
+++ b/src/features/operations/geographical-summary/components/geocoded-cluster-map.tsx
@@ -18,6 +18,7 @@ const DEFAULT_ZOOM = 2;
 
 interface GeocodedClusterMapProps {
     markers: GeocodableMarker[];
+    country: string;
     selectedLocations: string[];
     selectedMarkerId: string | null;
     onMarkerSelect: (id: string | null) => void;
@@ -28,6 +29,7 @@ interface GeocodedClusterMapProps {
 
 export default function GeocodedClusterMap({
     markers,
+    country,
     selectedLocations,
     selectedMarkerId,
     onMarkerSelect,
@@ -35,8 +37,10 @@ export default function GeocodedClusterMap({
     loadingLabel,
     renderSidePanel,
 }: GeocodedClusterMapProps) {
-    const { markerIdsToGeocodedPosition, isGeocoding } =
-        useSiteGeocode(markers);
+    const { markerIdsToGeocodedPosition, isGeocoding } = useSiteGeocode(
+        markers,
+        country,
+    );
 
     const markerBounds = useMemo(
         () => buildGeocodedBounds(markers, markerIdsToGeocodedPosition),

--- a/src/features/operations/geographical-summary/components/geocoded-cluster-map.tsx
+++ b/src/features/operations/geographical-summary/components/geocoded-cluster-map.tsx
@@ -59,6 +59,7 @@ export default function GeocodedClusterMap({
                 >
                     <MapNavigator
                         bounds={markerBounds}
+                        country={country}
                         selectedLocations={selectedLocations}
                     />
                     <TileLayer

--- a/src/features/operations/geographical-summary/components/map-navigator.tsx
+++ b/src/features/operations/geographical-summary/components/map-navigator.tsx
@@ -11,17 +11,19 @@ const SELECTED_LOCATION_ZOOM = 10;
 
 interface MapNavigatorProps {
     bounds: LatLngBoundsExpression | null;
+    country: string;
     selectedLocations: string[];
 }
 
 export default function MapNavigator({
     bounds,
+    country,
     selectedLocations,
 }: MapNavigatorProps) {
     const map = useMap();
 
     const { data: geocodeResult } = useGetGeocode(
-        { location: selectedLocations[0] ?? '' },
+        { location: selectedLocations[0] ?? '', country },
         { enabled: !bounds },
     );
 

--- a/src/features/operations/geographical-summary/components/operations-geographical-summary.tsx
+++ b/src/features/operations/geographical-summary/components/operations-geographical-summary.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import dynamic from 'next/dynamic';
 import { useTranslations } from 'next-intl';
+import { useGetPrograms } from '@/api/program/hooks/use-get-programs';
 import { useSiteMarkers } from '@/features/operations/geographical-summary/hooks/use-site-markers';
 import DeviceView from '@/features/operations/geographical-summary/components/device-view';
 import type { Site } from '@/api/site/validation/site-schema';
@@ -39,15 +40,36 @@ export default function OperationsGeographicalSummary({
     selectedMarkerId,
     setSelectedMarkerId,
 }: OperationsGeographicalSummaryProps) {
-    const { markers, totalSites, isPending, isError } = useSiteMarkers({
+    const {
+        markers,
+        totalSites,
+        isPending: isMarkersPending,
+        isError: isMarkersError,
+    } = useSiteMarkers({
         siteIds,
         descendantsOfSelectedLocations,
         startDate,
         endDate,
     });
 
+    const {
+        data: getProgramsResult,
+        isPending: isProgramsPending,
+        isError: isProgramsError,
+    } = useGetPrograms();
+
+    const country = getProgramsResult?.ok
+        ? getProgramsResult.data.programs.find(
+              program => program.programId === programId,
+          )?.country
+        : undefined;
+
+    const isPending = isMarkersPending || isProgramsPending;
+    const isError = isMarkersError || isProgramsError;
+
     const siteMapMounted = useRef(false);
-    if (!isPending && markers.length > 0) siteMapMounted.current = true;
+    if (!isPending && markers.length > 0 && country)
+        siteMapMounted.current = true;
 
     const t = useTranslations('OperationsGeographicalSummary');
     const [{ selectedLocations }] = useOperationsFilters();
@@ -74,9 +96,10 @@ export default function OperationsGeographicalSummary({
                 </TabsList>
             </Tabs>
 
-            {geographicalView === 'devices' && (
+            {geographicalView === 'devices' && country && (
                 <DeviceView
                     programId={programId}
+                    country={country}
                     siteIds={siteIds}
                     selectedLocations={selectedLocations}
                     descendantsOfSelectedLocations={
@@ -104,31 +127,25 @@ export default function OperationsGeographicalSummary({
 
                     <Card className="border-border/50 p-0">
                         <CardContent className="relative h-125 p-0">
-                            {siteMapMounted.current ? (
+                            {siteMapMounted.current && country ? (
                                 <SiteMap
                                     markers={markers}
+                                    country={country}
                                     selectedLocations={selectedLocations}
                                     selectedMarkerId={selectedMarkerId}
                                     onMarkerSelect={setSelectedMarkerId}
                                 />
-                            ) : isPending ? (
-                                <Skeleton className="h-full w-full rounded-md" />
                             ) : isError ? (
                                 <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
                                     Failed to load session data. Check the
                                     console for details.
                                 </div>
-                            ) : markers.length === 0 ? (
+                            ) : !isPending && markers.length === 0 ? (
                                 <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
                                     No site data found for the selected filters.
                                 </div>
                             ) : (
-                                <SiteMap
-                                    markers={markers}
-                                    selectedLocations={selectedLocations}
-                                    selectedMarkerId={selectedMarkerId}
-                                    onMarkerSelect={setSelectedMarkerId}
-                                />
+                                <Skeleton className="h-full w-full rounded-md" />
                             )}
                         </CardContent>
                     </Card>

--- a/src/features/operations/geographical-summary/components/site-map.tsx
+++ b/src/features/operations/geographical-summary/components/site-map.tsx
@@ -10,6 +10,7 @@ import MarkerInfoPanel from '@/features/operations/geographical-summary/componen
 
 interface SiteMapProps {
     markers: SiteMarker[];
+    country: string;
     selectedLocations: string[];
     selectedMarkerId: string | null;
     onMarkerSelect: (id: string | null) => void;
@@ -17,6 +18,7 @@ interface SiteMapProps {
 
 export default function SiteMap({
     markers,
+    country,
     selectedLocations,
     selectedMarkerId,
     onMarkerSelect,
@@ -31,6 +33,7 @@ export default function SiteMap({
     return (
         <GeocodedClusterMap
             markers={markers}
+            country={country}
             selectedLocations={selectedLocations}
             selectedMarkerId={selectedMarkerId}
             onMarkerSelect={onMarkerSelect}

--- a/src/features/operations/geographical-summary/hooks/use-site-geocode.ts
+++ b/src/features/operations/geographical-summary/hooks/use-site-geocode.ts
@@ -7,7 +7,10 @@ import { useQueryClient } from '@tanstack/react-query';
 import type { Geocode } from '@/api/geocode/validation/geocode-schema';
 import type { GeocodableMarker } from '@/features/operations/geographical-summary/utils/geographical-summary-helpers';
 
-export function useSiteGeocode(markers: GeocodableMarker[]): {
+export function useSiteGeocode(
+    markers: GeocodableMarker[],
+    country: string,
+): {
     markerIdsToGeocodedPosition: Map<string, Geocode>;
     isGeocoding: boolean;
 } {
@@ -48,10 +51,12 @@ export function useSiteGeocode(markers: GeocodableMarker[]): {
                 const geocodeResult = await queryClient.fetchQuery({
                     queryKey: geocodeKeys.geocode({
                         location: marker.locationQuery,
+                        country,
                     }),
                     queryFn: () =>
                         fetchGeocode({
                             location: marker.locationQuery,
+                            country,
                         }),
                 });
 
@@ -71,7 +76,7 @@ export function useSiteGeocode(markers: GeocodableMarker[]): {
             cancelled = true;
             setIsGeocoding(false);
         };
-    }, [markerIds, queryClient]);
+    }, [markerIds, country, queryClient]);
 
     return { markerIdsToGeocodedPosition, isGeocoding };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3403,6 +3403,11 @@ devlop@^1.0.0, devlop@^1.1.0:
   dependencies:
     dequal "^2.0.0"
 
+diacritics@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/diacritics/-/diacritics-1.3.0.tgz#3efa87323ebb863e6696cebb0082d48ff3d6f7a1"
+  integrity sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA==
+
 doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz"
@@ -4459,6 +4464,13 @@ human-signals@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
   integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
+
+i18n-iso-countries@^7.14.0:
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/i18n-iso-countries/-/i18n-iso-countries-7.14.0.tgz#cd5ae098198bce1cc40cadbf0a37ce6c8e9d0edf"
+  integrity sha512-nXHJZYtNrfsi1UQbyRqm3Gou431elgLjKl//CYlnBGt5aTWdRPH1PiS2T/p/n8Q8LnqYqzQJik3Q7mkwvLokeg==
+  dependencies:
+    diacritics "1.3.0"
 
 iconv-lite@0.6:
   version "0.6.3"


### PR DESCRIPTION
## Summary

Site markers on the Operations map can render in the wrong country entirely (e.g. a Ghana site landing in Sri Lanka), because Nominatim disambiguates same-named regions by importance alone. 
This PR makes every geocode lookup toward the site's actual program country via Nominatim's `countrycodes` param.

- Added `i18n-iso-countries` to resolve the program's stored country name (e.g. `"Ghana"`) to an ISO alpha-2 code (`gh`) that Nominatim's `countrycodes` expects. Avoids hand-maintaining a name→code map that would need updating on every new program country; the library's static table covers every country up front. 
- `country` is now a required input threaded through `SiteMap` and the device-activity map (`DeviceView`/`DeviceMap`) down to the shared geocoding hook, so no marker geocodes without a country bias.

