### PR TITLE
VCV-271: Loading State - Operations

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -75,6 +75,11 @@
         "noSpeciesFound": "No species found."
     },
     "OperationsAIPerformance": {
+        "coverageReflects": "Coverage reflects reviewed specimens for the selected location(s) where review means annotated or flagged.",
+        "coverage": "Coverage",
+        "reviewedOfTotal": "{count} reviewed / {total} specimens",
+        "reviewedSpecimens": "Reviewed Specimens",
+        "annotatedAndFlagged": "{annotated} annotated and {flagged} flagged",
         "accuracy": "Accuracy",
         "correctOf": "{numCorrect} correct of {total} {category} comparisons",
         "noConfusionMatrixData": "No verified {category} comparisons in this date range; there are no annotations to compare with VectorCam's predictions.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -67,8 +67,8 @@
         "legendInactive": "All devices inactive"
     },
     "OperationsSpecimenComposition": {
-        "monthlySpecimenCountsLoading": "LOADING...",
-        "monthlySpecimenCountsError": "ERROR: ",
+        "monthlySpecimenCountsError": "There was a problem fetching the specimen counts. Please try again later or contact support.",
+        "monthlySpecimenCountsEmpty": "No specimens found for this date range and species filter.",
         "filterBySpecies": "Filter by Species",
         "selectSpecies": "Select species...",
         "searchSpecies": "Search species...",

--- a/src/components/ui/empty-banner.tsx
+++ b/src/components/ui/empty-banner.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from 'react';
-import { cn } from '@/utils/cn';
 
 interface EmptyBannerProps {
     message: string;

--- a/src/components/ui/empty-banner.tsx
+++ b/src/components/ui/empty-banner.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import { cn } from '@/utils/cn';
+
+interface EmptyBannerProps {
+    message: string;
+    children?: ReactElement;
+}
+
+export default function EmptyBanner({ message, children }: EmptyBannerProps) {
+    return (
+        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-16 text-center">
+            {children}
+            <p className="text-muted-foreground text-sm">{message}</p>
+        </div>
+    );
+}

--- a/src/features/operations/ai-performance/components/operations-ai-performance.tsx
+++ b/src/features/operations/ai-performance/components/operations-ai-performance.tsx
@@ -5,6 +5,8 @@ import type { GetAnnotationsSummaryQueryParams } from '@/api/annotation/validati
 import { Card, CardContent } from '@/components/ui/card';
 import SpecimenConfusionMatrix from './specimen-confusion-matrix';
 import { Info } from 'lucide-react';
+import { Fragment } from 'react/jsx-runtime';
+import { Skeleton } from '@/components/ui/skeleton';
 
 interface OperationsAiPerformanceProps {
     siteIds: number[];
@@ -28,11 +30,10 @@ export default function OperationsAiPerformance({
         isPending: isGetAnnotationsSummaryPending,
     } = useGetAnnotationsSummary(annotationsSummaryQueryParams);
 
-    if (isGetAnnotationsSummaryPending || !getAnnotationsSummaryResult) {
-        return <p className="text-muted-foreground text-sm">Loading...</p>;
-    }
+    const isLoading =
+        isGetAnnotationsSummaryPending || !getAnnotationsSummaryResult;
 
-    if (!getAnnotationsSummaryResult.ok) {
+    if (!isLoading && !getAnnotationsSummaryResult.ok) {
         return (
             <p className="text-destructive text-sm">
                 {getAnnotationsSummaryResult.error.message ??
@@ -41,14 +42,21 @@ export default function OperationsAiPerformance({
         );
     }
 
-    const annotationsSummary = getAnnotationsSummaryResult.data;
-    const annotatedSpecimens = annotationsSummary.statusCounts.ANNOTATED;
-    const flaggedSpecimens = annotationsSummary.statusCounts.FLAGGED;
-    const reviewedSpecimens = annotatedSpecimens + flaggedSpecimens;
-    const totalSpecimens = annotationsSummary.total;
+    const annotationsSummary = getAnnotationsSummaryResult?.ok
+        ? getAnnotationsSummaryResult.data
+        : undefined;
+    const annotatedSpecimens = annotationsSummary?.statusCounts.ANNOTATED;
+    const flaggedSpecimens = annotationsSummary?.statusCounts.FLAGGED;
+    const reviewedSpecimens =
+        annotatedSpecimens && flaggedSpecimens
+            ? annotatedSpecimens + flaggedSpecimens
+            : 0;
+    const totalSpecimens = annotationsSummary?.total || 0;
 
     const reviewedSpecimensCoverage =
-        totalSpecimens > 0 ? (reviewedSpecimens / totalSpecimens) * 100 : null;
+        totalSpecimens && reviewedSpecimens && totalSpecimens > 0
+            ? (reviewedSpecimens / totalSpecimens) * 100
+            : null;
 
     return (
         <div className="space-y-4">
@@ -61,73 +69,96 @@ export default function OperationsAiPerformance({
             </div>
 
             <div className="grid gap-3 lg:col-span-2 lg:grid-cols-2">
-                <Card className="border-success/40 bg-success/5 gap-0 py-0">
-                    <CardContent className="p-4">
-                        <p className="text-muted-foreground text-sm">
-                            Coverage
-                        </p>
-                        <p className="mt-1 text-4xl font-semibold tracking-tight">
-                            {reviewedSpecimensCoverage !== null
-                                ? `${reviewedSpecimensCoverage.toFixed(1)}%`
-                                : '—'}
-                        </p>
-                        <p className="text-muted-foreground mt-2 text-xs">
-                            {reviewedSpecimens.toLocaleString()} reviewed /{' '}
-                            {totalSpecimens.toLocaleString()} total specimens
-                        </p>
-                    </CardContent>
-                </Card>
+                <Fragment>
+                    <Card className="border-success/40 bg-success/5 gap-0 py-0">
+                        <CardContent className="p-4">
+                            <p className="text-muted-foreground text-sm">
+                                Coverage
+                            </p>
+                            {isLoading ? (
+                                <div className="space-y-2 py-2">
+                                    <Skeleton width="sm" height="xl" />
+                                    <Skeleton width="lg" height="sm" />
+                                </div>
+                            ) : (
+                                <Fragment>
+                                    <p className="mt-1 text-4xl font-semibold tracking-tight">
+                                        {reviewedSpecimensCoverage !== null
+                                            ? `${reviewedSpecimensCoverage.toFixed(1)}%`
+                                            : '—'}
+                                    </p>
 
-                <Card className="border-border bg-card gap-0 py-0">
-                    <CardContent className="p-4">
-                        <p className="text-muted-foreground text-sm">
-                            Reviewed Specimens
-                        </p>
-                        <p className="mt-1 text-4xl font-semibold tracking-tight">
-                            {reviewedSpecimens.toLocaleString()}
-                        </p>
-                        <p className="text-muted-foreground mt-2 text-xs">
-                            {annotatedSpecimens.toLocaleString()} annotated and{' '}
-                            {flaggedSpecimens.toLocaleString()} flagged
-                        </p>
-                    </CardContent>
-                </Card>
+                                    <p className="text-muted-foreground mt-2 text-xs">
+                                        {reviewedSpecimens.toLocaleString()}{' '}
+                                        reviewed /{' '}
+                                        {totalSpecimens.toLocaleString()} total
+                                        specimens
+                                    </p>
+                                </Fragment>
+                            )}
+                        </CardContent>
+                    </Card>
 
-                {annotationsSummary.confusionMatrices?.species && (
-                    <SpecimenConfusionMatrix
-                        title="Species Confusion Matrix"
-                        classificationCategory="species"
-                        groundTruthAxisLabel="Visual Verification Species Label"
-                        predictionAxisLabel="VectorCam Species Label"
-                        confusionMatrix={
-                            annotationsSummary.confusionMatrices.species
-                        }
-                    />
-                )}
+                    <Card className="border-border bg-card gap-0 py-0">
+                        <CardContent className="p-4">
+                            <p className="text-muted-foreground text-sm">
+                                Reviewed Specimens
+                            </p>
+                            {isLoading ? (
+                                <div className="space-y-2 py-2">
+                                    <Skeleton width="sm" height="xl" />
+                                    <Skeleton width="lg" height="sm" />
+                                </div>
+                            ) : (
+                                <Fragment>
+                                    <p className="mt-1 text-4xl font-semibold tracking-tight">
+                                        {reviewedSpecimens?.toLocaleString() ||
+                                            '—'}
+                                    </p>
+                                    <p className="text-muted-foreground mt-2 text-xs">
+                                        {annotatedSpecimens?.toLocaleString() ||
+                                            '—'}{' '}
+                                        annotated and{' '}
+                                        {flaggedSpecimens?.toLocaleString() ||
+                                            '—'}{' '}
+                                        flagged
+                                    </p>
+                                </Fragment>
+                            )}
+                        </CardContent>
+                    </Card>
+                </Fragment>
 
-                {annotationsSummary.confusionMatrices?.sex && (
-                    <SpecimenConfusionMatrix
-                        title="Sex Confusion Matrix"
-                        classificationCategory="sex"
-                        groundTruthAxisLabel="Visual Verification Sex Label"
-                        predictionAxisLabel="VectorCam Sex Label"
-                        confusionMatrix={
-                            annotationsSummary.confusionMatrices.sex
-                        }
-                    />
-                )}
+                <SpecimenConfusionMatrix
+                    title="Species Confusion Matrix"
+                    classificationCategory="species"
+                    groundTruthAxisLabel="Visual Verification Species Label"
+                    predictionAxisLabel="VectorCam Species Label"
+                    confusionMatrix={
+                        annotationsSummary?.confusionMatrices?.species
+                    }
+                    isLoading={isLoading}
+                />
 
-                {annotationsSummary.confusionMatrices?.abdomenStatus && (
-                    <SpecimenConfusionMatrix
-                        title="Abdomen Status Confusion Matrix"
-                        classificationCategory="abdomen status"
-                        groundTruthAxisLabel="Visual Verification Abdomen Status Label"
-                        predictionAxisLabel="VectorCam Abdomen Status Label"
-                        confusionMatrix={
-                            annotationsSummary.confusionMatrices.abdomenStatus
-                        }
-                    />
-                )}
+                <SpecimenConfusionMatrix
+                    title="Sex Confusion Matrix"
+                    classificationCategory="sex"
+                    groundTruthAxisLabel="Visual Verification Sex Label"
+                    predictionAxisLabel="VectorCam Sex Label"
+                    confusionMatrix={annotationsSummary?.confusionMatrices?.sex}
+                    isLoading={isLoading}
+                />
+
+                <SpecimenConfusionMatrix
+                    title="Abdomen Status Confusion Matrix"
+                    classificationCategory="abdomen status"
+                    groundTruthAxisLabel="Visual Verification Abdomen Status Label"
+                    predictionAxisLabel="VectorCam Abdomen Status Label"
+                    confusionMatrix={
+                        annotationsSummary?.confusionMatrices?.abdomenStatus
+                    }
+                    isLoading={isLoading}
+                />
             </div>
         </div>
     );

--- a/src/features/operations/ai-performance/components/operations-ai-performance.tsx
+++ b/src/features/operations/ai-performance/components/operations-ai-performance.tsx
@@ -7,6 +7,7 @@ import SpecimenConfusionMatrix from './specimen-confusion-matrix';
 import { Info } from 'lucide-react';
 import { Fragment } from 'react/jsx-runtime';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useTranslations } from 'next-intl';
 
 interface OperationsAiPerformanceProps {
     siteIds: number[];
@@ -19,6 +20,7 @@ export default function OperationsAiPerformance({
     startDate,
     endDate,
 }: OperationsAiPerformanceProps) {
+    const t = useTranslations('OperationsAIPerformance');
     const annotationsSummaryQueryParams: GetAnnotationsSummaryQueryParams = {
         siteIds,
         startDate,
@@ -54,7 +56,7 @@ export default function OperationsAiPerformance({
     const totalSpecimens = annotationsSummary?.total || 0;
 
     const reviewedSpecimensCoverage =
-        totalSpecimens && reviewedSpecimens && totalSpecimens > 0
+        totalSpecimens && totalSpecimens > 0
             ? (reviewedSpecimens / totalSpecimens) * 100
             : null;
 
@@ -62,10 +64,7 @@ export default function OperationsAiPerformance({
         <div className="space-y-4">
             <div className="border-accent bg-accent/40 text-accent-foreground flex items-center gap-2 rounded-lg border px-4 py-3 text-sm">
                 <Info className="h-4 w-4" />
-                <span>
-                    Coverage reflects reviewed specimens for the selected
-                    location(s) where review means annotated or flagged.
-                </span>
+                <span>{t('coverageReflects')}</span>
             </div>
 
             <div className="grid gap-3 lg:col-span-2 lg:grid-cols-2">
@@ -73,7 +72,7 @@ export default function OperationsAiPerformance({
                     <Card className="border-success/40 bg-success/5 gap-0 py-0">
                         <CardContent className="p-4">
                             <p className="text-muted-foreground text-sm">
-                                Coverage
+                                {t('coverage')}
                             </p>
                             {isLoading ? (
                                 <div className="space-y-2 py-2">
@@ -89,10 +88,10 @@ export default function OperationsAiPerformance({
                                     </p>
 
                                     <p className="text-muted-foreground mt-2 text-xs">
-                                        {reviewedSpecimens.toLocaleString()}{' '}
-                                        reviewed /{' '}
-                                        {totalSpecimens.toLocaleString()} total
-                                        specimens
+                                        {t('reviewedOfTotal', {
+                                            count: reviewedSpecimens.toLocaleString(),
+                                            total: totalSpecimens.toLocaleString(),
+                                        })}
                                     </p>
                                 </Fragment>
                             )}
@@ -102,7 +101,7 @@ export default function OperationsAiPerformance({
                     <Card className="border-border bg-card gap-0 py-0">
                         <CardContent className="p-4">
                             <p className="text-muted-foreground text-sm">
-                                Reviewed Specimens
+                                {t('reviewedSpecimens')}
                             </p>
                             {isLoading ? (
                                 <div className="space-y-2 py-2">
@@ -116,12 +115,14 @@ export default function OperationsAiPerformance({
                                             '—'}
                                     </p>
                                     <p className="text-muted-foreground mt-2 text-xs">
-                                        {annotatedSpecimens?.toLocaleString() ||
-                                            '—'}{' '}
-                                        annotated and{' '}
-                                        {flaggedSpecimens?.toLocaleString() ||
-                                            '—'}{' '}
-                                        flagged
+                                        {t('annotatedAndFlagged', {
+                                            annotated:
+                                                annotatedSpecimens?.toLocaleString() ||
+                                                '—',
+                                            flagged:
+                                                flaggedSpecimens?.toLocaleString() ||
+                                                '—',
+                                        })}
                                     </p>
                                 </Fragment>
                             )}

--- a/src/features/operations/ai-performance/components/operations-ai-performance.tsx
+++ b/src/features/operations/ai-performance/components/operations-ai-performance.tsx
@@ -50,7 +50,7 @@ export default function OperationsAiPerformance({
     const annotatedSpecimens = annotationsSummary?.statusCounts.ANNOTATED;
     const flaggedSpecimens = annotationsSummary?.statusCounts.FLAGGED;
     const reviewedSpecimens =
-        annotatedSpecimens && flaggedSpecimens
+        annotatedSpecimens != null && flaggedSpecimens != null
             ? annotatedSpecimens + flaggedSpecimens
             : 0;
     const totalSpecimens = annotationsSummary?.total || 0;

--- a/src/features/operations/ai-performance/components/specimen-confusion-matrix.tsx
+++ b/src/features/operations/ai-performance/components/specimen-confusion-matrix.tsx
@@ -16,6 +16,9 @@ import {
 import { cn } from '@/utils/cn';
 import { Bot } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { Fragment } from 'react/jsx-runtime';
+import { Skeleton } from '@/components/ui/skeleton';
+import { SkeletonList } from '@/components/ui/skeleton-list';
 
 const EXCLUDED_LABELS = ['unknown', 'Cannot be Determined'] as const;
 
@@ -24,7 +27,8 @@ interface SpecimenConfusionMatrixProps {
     classificationCategory: string;
     groundTruthAxisLabel: string;
     predictionAxisLabel: string;
-    confusionMatrix: AnnotationConfusionMatrix;
+    confusionMatrix: AnnotationConfusionMatrix | undefined;
+    isLoading: boolean;
 }
 
 export default function SpecimenConfusionMatrix({
@@ -33,21 +37,24 @@ export default function SpecimenConfusionMatrix({
     groundTruthAxisLabel,
     predictionAxisLabel,
     confusionMatrix,
+    isLoading,
 }: SpecimenConfusionMatrixProps) {
     const t = useTranslations('OperationsAIPerformance');
 
-    const classLabels = Array.from(
-        new Set([
-            ...confusionMatrix.columns,
-            ...confusionMatrix.data.map(({ rowLabel }) => rowLabel),
-        ]),
-    );
+    const classLabels = confusionMatrix
+        ? Array.from(
+              new Set([
+                  ...confusionMatrix.columns,
+                  ...confusionMatrix.data.map(({ rowLabel }) => rowLabel),
+              ]),
+          )
+        : [];
 
     function getSpecimenCountForCell(
         groundTruthLabel: string,
         predictedLabel: string,
     ) {
-        const specimenCount = confusionMatrix.data.find(
+        const specimenCount = confusionMatrix?.data.find(
             row => row.rowLabel === groundTruthLabel,
         )?.values[predictedLabel];
 
@@ -157,27 +164,38 @@ export default function SpecimenConfusionMatrix({
                     <p className="text-muted-foreground text-sm">
                         {t('accuracy')}
                     </p>
-                    <p className="mt-1 text-4xl font-semibold tracking-tight">
-                        {formatMatrixPercentage(accuracy)}
-                    </p>
-                    <p className="text-muted-foreground mt-2 text-xs">
-                        {t('correctOf', {
-                            numCorrect: integerCountFormatter.format(
-                                totalCorrectPredictions,
-                            ),
-                            total: integerCountFormatter.format(
-                                totalSpecimensInMatrix,
-                            ),
-                            category: classificationCategory,
-                        })}
-                    </p>
+                    {isLoading ? (
+                        <div className="space-y-2 py-2">
+                            <Skeleton width="sm" height="xl" />
+                            <Skeleton width="lg" height="sm" />
+                        </div>
+                    ) : (
+                        <Fragment>
+                            <p className="mt-1 text-4xl font-semibold tracking-tight">
+                                {formatMatrixPercentage(accuracy)}
+                            </p>
+                            <p className="text-muted-foreground mt-2 text-xs">
+                                {t('correctOf', {
+                                    numCorrect: integerCountFormatter.format(
+                                        totalCorrectPredictions,
+                                    ),
+                                    total: integerCountFormatter.format(
+                                        totalSpecimensInMatrix,
+                                    ),
+                                    category: classificationCategory,
+                                })}
+                            </p>
+                        </Fragment>
+                    )}
                 </div>
 
                 <div className="max-w-full">
                     <Table className="min-w-180 table-fixed border-collapse overflow-hidden rounded-lg">
                         <TableHeader>
                             <TableRow className="hover:bg-transparent">
-                                <TableHead className="bg-muted/40 h-12 w-60 border" />
+                                {!isLoading && (
+                                    <TableHead className="bg-muted/40 h-12 w-60 border" />
+                                )}
                                 <TableHead
                                     className="bg-muted/40 h-auto min-h-12 border px-3 py-3 text-center leading-snug font-semibold wrap-break-word whitespace-normal"
                                     colSpan={classLabels.length}
@@ -185,85 +203,92 @@ export default function SpecimenConfusionMatrix({
                                     {predictionAxisLabel}
                                 </TableHead>
                             </TableRow>
-                            <TableRow className="hover:bg-transparent">
-                                <TableHead className="bg-muted/20 h-auto border px-3 py-3 text-center text-sm leading-snug font-semibold wrap-break-word whitespace-normal">
-                                    {groundTruthAxisLabel}
-                                </TableHead>
-                                {classLabels.map(predictedLabel => (
-                                    <TableHead
-                                        key={predictedLabel}
-                                        className="bg-muted/20 border px-2 text-center text-xs font-semibold"
-                                    >
-                                        <span className="line-clamp-2 whitespace-normal">
-                                            {predictedLabel}
-                                        </span>
+                            {!isLoading && (
+                                <TableRow className="hover:bg-transparent">
+                                    <TableHead className="bg-muted/20 h-auto border px-3 py-3 text-center text-sm leading-snug font-semibold wrap-break-word whitespace-normal">
+                                        {groundTruthAxisLabel}
                                     </TableHead>
-                                ))}
-                            </TableRow>
+                                    {classLabels.map(predictedLabel => (
+                                        <TableHead
+                                            key={predictedLabel}
+                                            className="bg-muted/20 border px-2 text-center text-xs font-semibold"
+                                        >
+                                            <span className="line-clamp-2 whitespace-normal">
+                                                {predictedLabel}
+                                            </span>
+                                        </TableHead>
+                                    ))}
+                                </TableRow>
+                            )}
                         </TableHeader>
 
-                        <TableBody>
-                            {classLabels.map(groundTruthLabel => {
-                                const groundTruthLabelTotal =
-                                    getSpecimenCountForGroundTruthLabel(
-                                        groundTruthLabel,
+                        {!isLoading && (
+                            <TableBody>
+                                {classLabels.map(groundTruthLabel => {
+                                    const groundTruthLabelTotal =
+                                        getSpecimenCountForGroundTruthLabel(
+                                            groundTruthLabel,
+                                        );
+
+                                    return (
+                                        <TableRow
+                                            key={groundTruthLabel}
+                                            className="hover:bg-transparent"
+                                        >
+                                            <TableCell className="bg-background border text-center text-xs font-medium whitespace-normal">
+                                                {groundTruthLabel}
+                                            </TableCell>
+
+                                            {classLabels.map(predictedLabel => {
+                                                const specimenCountForCell =
+                                                    getSpecimenCountForCell(
+                                                        groundTruthLabel,
+                                                        predictedLabel,
+                                                    );
+                                                const groundTruthLabelShare =
+                                                    groundTruthLabelTotal > 0
+                                                        ? specimenCountForCell /
+                                                          groundTruthLabelTotal
+                                                        : null;
+                                                const isCorrectPrediction =
+                                                    groundTruthLabel ===
+                                                    predictedLabel;
+                                                const cellPresentation =
+                                                    getMatrixCellPresentation(
+                                                        groundTruthLabelShare,
+                                                        isCorrectPrediction,
+                                                    );
+
+                                                return (
+                                                    <TableCell
+                                                        key={`${groundTruthLabel}-${predictedLabel}`}
+                                                        className={cn(
+                                                            'border p-0',
+                                                            cellPresentation.className,
+                                                        )}
+                                                        style={
+                                                            cellPresentation.style
+                                                        }
+                                                    >
+                                                        <div className="flex min-h-20 items-center justify-center px-2 py-3 text-center">
+                                                            <span className="text-base font-semibold">
+                                                                {integerCountFormatter.format(
+                                                                    specimenCountForCell,
+                                                                )}
+                                                            </span>
+                                                        </div>
+                                                    </TableCell>
+                                                );
+                                            })}
+                                        </TableRow>
                                     );
-
-                                return (
-                                    <TableRow
-                                        key={groundTruthLabel}
-                                        className="hover:bg-transparent"
-                                    >
-                                        <TableCell className="bg-background border text-center text-xs font-medium whitespace-normal">
-                                            {groundTruthLabel}
-                                        </TableCell>
-
-                                        {classLabels.map(predictedLabel => {
-                                            const specimenCountForCell =
-                                                getSpecimenCountForCell(
-                                                    groundTruthLabel,
-                                                    predictedLabel,
-                                                );
-                                            const groundTruthLabelShare =
-                                                groundTruthLabelTotal > 0
-                                                    ? specimenCountForCell /
-                                                      groundTruthLabelTotal
-                                                    : null;
-                                            const isCorrectPrediction =
-                                                groundTruthLabel ===
-                                                predictedLabel;
-                                            const cellPresentation =
-                                                getMatrixCellPresentation(
-                                                    groundTruthLabelShare,
-                                                    isCorrectPrediction,
-                                                );
-
-                                            return (
-                                                <TableCell
-                                                    key={`${groundTruthLabel}-${predictedLabel}`}
-                                                    className={cn(
-                                                        'border p-0',
-                                                        cellPresentation.className,
-                                                    )}
-                                                    style={
-                                                        cellPresentation.style
-                                                    }
-                                                >
-                                                    <div className="flex min-h-20 items-center justify-center px-2 py-3 text-center">
-                                                        <span className="text-base font-semibold">
-                                                            {integerCountFormatter.format(
-                                                                specimenCountForCell,
-                                                            )}
-                                                        </span>
-                                                    </div>
-                                                </TableCell>
-                                            );
-                                        })}
-                                    </TableRow>
-                                );
-                            })}
-                        </TableBody>
+                                })}
+                            </TableBody>
+                        )}
                     </Table>
+                    {isLoading && (
+                        <SkeletonList count={3} width="full" height="xxl" />
+                    )}
                 </div>
 
                 <div className="grid items-stretch gap-4 lg:grid-cols-[500px_minmax(0,1fr)]">
@@ -291,72 +316,80 @@ export default function SpecimenConfusionMatrix({
                             </TableHeader>
 
                             <TableBody>
-                                {filteredClassLabels.map(classLabel => {
-                                    const truePositives =
-                                        getSpecimenCountForCell(
-                                            classLabel,
-                                            classLabel,
+                                {!isLoading &&
+                                    filteredClassLabels.map(classLabel => {
+                                        const truePositives =
+                                            getSpecimenCountForCell(
+                                                classLabel,
+                                                classLabel,
+                                            );
+                                        const falseNegatives =
+                                            getSpecimenCountForGroundTruthLabel(
+                                                classLabel,
+                                                filteredClassLabels,
+                                            ) - truePositives;
+                                        const falsePositives =
+                                            getSpecimenCountForPredictedLabel(
+                                                classLabel,
+                                                filteredClassLabels,
+                                            ) - truePositives;
+                                        const trueNegatives =
+                                            filteredTotalSpecimens -
+                                            truePositives -
+                                            falseNegatives -
+                                            falsePositives;
+
+                                        const sensitivity =
+                                            truePositives + falseNegatives > 0
+                                                ? truePositives /
+                                                  (truePositives +
+                                                      falseNegatives)
+                                                : null;
+                                        const specificity =
+                                            trueNegatives + falsePositives > 0
+                                                ? trueNegatives /
+                                                  (trueNegatives +
+                                                      falsePositives)
+                                                : null;
+
+                                        return (
+                                            <TableRow
+                                                key={classLabel}
+                                                className="hover:bg-transparent"
+                                            >
+                                                <TableCell className="font-medium whitespace-nowrap">
+                                                    {classLabel}
+                                                </TableCell>
+                                                <TableCell className="text-muted-foreground text-right">
+                                                    {formatMatrixPercentage(
+                                                        sensitivity,
+                                                    )}
+                                                </TableCell>
+                                                <TableCell className="text-muted-foreground text-right">
+                                                    {formatMatrixPercentage(
+                                                        specificity,
+                                                    )}
+                                                </TableCell>
+                                            </TableRow>
                                         );
-                                    const falseNegatives =
-                                        getSpecimenCountForGroundTruthLabel(
-                                            classLabel,
-                                            filteredClassLabels,
-                                        ) - truePositives;
-                                    const falsePositives =
-                                        getSpecimenCountForPredictedLabel(
-                                            classLabel,
-                                            filteredClassLabels,
-                                        ) - truePositives;
-                                    const trueNegatives =
-                                        filteredTotalSpecimens -
-                                        truePositives -
-                                        falseNegatives -
-                                        falsePositives;
-
-                                    const sensitivity =
-                                        truePositives + falseNegatives > 0
-                                            ? truePositives /
-                                              (truePositives + falseNegatives)
-                                            : null;
-                                    const specificity =
-                                        trueNegatives + falsePositives > 0
-                                            ? trueNegatives /
-                                              (trueNegatives + falsePositives)
-                                            : null;
-
-                                    return (
-                                        <TableRow
-                                            key={classLabel}
-                                            className="hover:bg-transparent"
-                                        >
-                                            <TableCell className="font-medium whitespace-nowrap">
-                                                {classLabel}
-                                            </TableCell>
-                                            <TableCell className="text-muted-foreground text-right">
-                                                {formatMatrixPercentage(
-                                                    sensitivity,
-                                                )}
-                                            </TableCell>
-                                            <TableCell className="text-muted-foreground text-right">
-                                                {formatMatrixPercentage(
-                                                    specificity,
-                                                )}
-                                            </TableCell>
-                                        </TableRow>
-                                    );
-                                })}
+                                    })}
                             </TableBody>
                         </Table>
-                        <p className="text-muted-foreground text-sm leading-6">
-                            {excludedSpecimenCounts.map(
-                                ({ excludedLabel, count }) => {
-                                    return t('specimensLabeledAs', {
-                                        count: count,
-                                        category: excludedLabel,
-                                    });
-                                },
-                            )}
-                        </p>
+                        {isLoading && (
+                            <SkeletonList count={3} height="lg" width="full" />
+                        )}
+                        {!isLoading && (
+                            <p className="text-muted-foreground text-sm leading-6">
+                                {excludedSpecimenCounts.map(
+                                    ({ excludedLabel, count }) => {
+                                        return t('specimensLabeledAs', {
+                                            count: count,
+                                            category: excludedLabel,
+                                        });
+                                    },
+                                )}
+                            </p>
+                        )}
                     </div>
 
                     <div className="h-full space-y-3 rounded-xl border p-4">

--- a/src/features/operations/ai-performance/components/specimen-confusion-matrix.tsx
+++ b/src/features/operations/ai-performance/components/specimen-confusion-matrix.tsx
@@ -96,7 +96,7 @@ export default function SpecimenConfusionMatrix({
         0,
     );
 
-    if (totalSpecimensInMatrix === 0) {
+    if (!isLoading && totalSpecimensInMatrix === 0) {
         return (
             <Card className="gap-0 lg:col-span-2">
                 <CardContent className="space-y-6">

--- a/src/features/operations/components/operations-page-client.tsx
+++ b/src/features/operations/components/operations-page-client.tsx
@@ -20,6 +20,7 @@ import {
     type OperationsTab,
 } from '@/features/operations/view-state/use-operations-filters';
 import { useTranslations } from 'next-intl';
+import EmptyBanner from '@/components/ui/empty-banner';
 
 const OPERATIONS_TABS: {
     value: OperationsTab;
@@ -158,12 +159,9 @@ export default function OperationsPageClient() {
                     <Separator />
 
                     {!selectedSiteIdsParam ? (
-                        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-16 text-center">
+                        <EmptyBanner message={t('selectALocation')}>
                             <Microscope className="text-muted-foreground/50 mb-4 h-12 w-12" />
-                            <p className="text-muted-foreground text-sm">
-                                {t('selectALocation')}
-                            </p>
-                        </div>
+                        </EmptyBanner>
                     ) : (
                         <Fragment>
                             {activeTab === 'specimen-composition' && (

--- a/src/features/operations/field-user-compliance/components/operations-field-user-compliance.tsx
+++ b/src/features/operations/field-user-compliance/components/operations-field-user-compliance.tsx
@@ -41,7 +41,6 @@ export default function OperationsFieldUserCompliance({
     if (isPending || !getAllSessionsResult) {
         return (
             <div className="space-y-4">
-                <Skeleton className="h-5 w-64" />
                 <Skeleton className="h-64 w-full" />
             </div>
         );

--- a/src/features/operations/geographical-summary/components/device-view.tsx
+++ b/src/features/operations/geographical-summary/components/device-view.tsx
@@ -103,8 +103,13 @@ export default function DeviceView({
 
             <Card className="border-border/50 p-0">
                 <CardContent className="relative h-125 p-0">
-                    {isPending || !deviceMarkers ? (
+                    {isPending ? (
                         <Skeleton className="h-full w-full rounded-md" />
+                    ) : !deviceMarkers ||
+                      deviceCounts.active + deviceCounts.inactive === 0 ? (
+                        <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
+                            {t('noDeviceActivity')}
+                        </div>
                     ) : (
                         <DeviceMap
                             markers={deviceMarkers}

--- a/src/features/operations/geographical-summary/components/device-view.tsx
+++ b/src/features/operations/geographical-summary/components/device-view.tsx
@@ -57,33 +57,11 @@ export default function DeviceView({
         );
     }, [deviceActivity, descendantsOfSelectedLocations, country]);
 
-    if (isPending) {
-        return (
-            <div className="space-y-3">
-                <div className="flex flex-wrap gap-3">
-                    <Skeleton className="h-13 w-28" />
-                    <Skeleton className="h-13 w-28" />
-                </div>
-                <Skeleton className="h-125 w-full rounded-md" />
-            </div>
-        );
-    }
-
     if (isError) {
         return (
             <Card className="border-border/50 p-0">
                 <CardContent className="text-muted-foreground flex h-125 items-center justify-center p-0 text-sm">
                     {t('deviceActivityError')}
-                </CardContent>
-            </Card>
-        );
-    }
-
-    if (!isPending && (!deviceMarkers || deviceMarkers.length === 0)) {
-        return (
-            <Card className="border-border/50 p-0">
-                <CardContent className="text-muted-foreground flex h-125 items-center justify-center p-0 text-sm">
-                    {t('noDeviceActivity')}
                 </CardContent>
             </Card>
         );

--- a/src/features/operations/geographical-summary/components/device-view.tsx
+++ b/src/features/operations/geographical-summary/components/device-view.tsx
@@ -56,18 +56,6 @@ export default function DeviceView({
         );
     }, [deviceActivity, descendantsOfSelectedLocations]);
 
-    if (isPending) {
-        return (
-            <div className="space-y-3">
-                <div className="flex flex-wrap gap-3">
-                    <Skeleton className="h-13 w-28" />
-                    <Skeleton className="h-13 w-28" />
-                </div>
-                <Skeleton className="h-125 w-full rounded-md" />
-            </div>
-        );
-    }
-
     if (isError) {
         return (
             <Card className="border-border/50 p-0">
@@ -78,7 +66,7 @@ export default function DeviceView({
         );
     }
 
-    if (!deviceMarkers || deviceMarkers.length === 0) {
+    if (!isPending && (!deviceMarkers || deviceMarkers.length === 0)) {
         return (
             <Card className="border-border/50 p-0">
                 <CardContent className="text-muted-foreground flex h-125 items-center justify-center p-0 text-sm">
@@ -88,13 +76,13 @@ export default function DeviceView({
         );
     }
 
-    const deviceCounts = deviceMarkers.reduce(
+    const deviceCounts = deviceMarkers?.reduce(
         (counts, marker) => ({
             active: counts.active + marker.activeDeviceCount,
             inactive: counts.inactive + marker.inactiveDeviceCount,
         }),
         { active: 0, inactive: 0 },
-    );
+    ) || { active: 0, inactive: 0 };
 
     const tiers = [
         { key: 'active', count: deviceCounts.active },
@@ -110,9 +98,13 @@ export default function DeviceView({
                             <p className="text-muted-foreground text-xs">
                                 {t(tier.key)}
                             </p>
-                            <p className="text-lg leading-none font-bold">
-                                {tier.count}
-                            </p>
+                            {isPending ? (
+                                <Skeleton className="h-5 w-8" />
+                            ) : (
+                                <p className="text-lg leading-none font-bold">
+                                    {tier.count}
+                                </p>
+                            )}
                         </CardContent>
                     </Card>
                 ))}
@@ -120,13 +112,17 @@ export default function DeviceView({
 
             <Card className="border-border/50 p-0">
                 <CardContent className="relative h-125 p-0">
-                    <DeviceMap
-                        markers={deviceMarkers}
-                        country={country}
-                        selectedLocations={selectedLocations}
-                        selectedMarkerId={selectedMarkerId}
-                        onMarkerSelect={setSelectedMarkerId}
-                    />
+                    {isPending || !deviceMarkers ? (
+                        <Skeleton className="h-full w-full rounded-md" />
+                    ) : (
+                        <DeviceMap
+                            markers={deviceMarkers}
+                            country={country}
+                            selectedLocations={selectedLocations}
+                            selectedMarkerId={selectedMarkerId}
+                            onMarkerSelect={setSelectedMarkerId}
+                        />
+                    )}
                 </CardContent>
             </Card>
 

--- a/src/features/operations/specimen-composition/components/composition-chart-pair.tsx
+++ b/src/features/operations/specimen-composition/components/composition-chart-pair.tsx
@@ -185,7 +185,7 @@ export default function CompositionChartPair({
                     </div>
                     <div className="h-72 w-full min-w-0 flex-1">
                         {isLoading ? (
-                            <Skeleton className="h-full w-full" />
+                            <Skeleton className="h-64 w-full" />
                         ) : (
                             <ChartContainer
                                 config={specimenChartConfig}

--- a/src/features/operations/specimen-composition/components/composition-chart-pair.tsx
+++ b/src/features/operations/specimen-composition/components/composition-chart-pair.tsx
@@ -106,7 +106,7 @@ export default function CompositionChartPair({
                 <CardTitle className="text-base">{title}</CardTitle>
             </CardHeader>
             <CardContent>
-                {totalSpecimenCount === 0 ? (
+                {!isLoading && totalSpecimenCount === 0 ? (
                     <div className="text-muted-foreground flex items-center justify-center py-12 text-sm">
                         {t('noSpecimenData')}
                     </div>

--- a/src/features/operations/specimen-composition/components/composition-chart-pair.tsx
+++ b/src/features/operations/specimen-composition/components/composition-chart-pair.tsx
@@ -22,6 +22,7 @@ import {
     YAxis,
 } from 'recharts';
 import { Fragment } from 'react/jsx-runtime';
+import { Skeleton } from '@/components/ui/skeleton';
 
 type ChartType = 'bar' | 'line';
 
@@ -34,6 +35,7 @@ interface CompositionChartPairProps {
     }[];
     specimenCountsByMonth: Record<string, string | number>[];
     specimenChartConfig: ChartConfig;
+    isLoading: boolean;
 }
 
 export default function CompositionChartPair({
@@ -42,6 +44,7 @@ export default function CompositionChartPair({
     specimenCountsByClass,
     specimenCountsByMonth,
     specimenChartConfig,
+    isLoading,
 }: CompositionChartPairProps) {
     const specimenClasses = Object.keys(specimenChartConfig);
     const totalSpecimenCount = specimenCountsByClass.reduce(
@@ -103,141 +106,152 @@ export default function CompositionChartPair({
             <CardContent>
                 <div className="flex flex-col items-center gap-6 lg:flex-row">
                     <div className="h-62.5 w-62.5 shrink-0">
-                        <ChartContainer
-                            config={specimenChartConfig}
-                            className="h-full w-full"
-                        >
-                            <PieChart>
-                                <ChartTooltip
-                                    cursor={false}
-                                    content={
-                                        <ChartTooltipContent
-                                            className="min-w-45"
-                                            indicator="line"
-                                        />
-                                    }
-                                />
-                                <Pie
-                                    data={specimenCountsByClass.map(
-                                        ({ specimenClass, specimenCount }) => ({
-                                            specimenClass,
-                                            specimenCount,
-                                            fill: specimenChartConfig[
-                                                specimenClass
-                                            ]?.color,
-                                        }),
-                                    )}
-                                    nameKey="specimenClass"
-                                    dataKey="specimenCount"
-                                    innerRadius={60}
-                                    outerRadius={80}
-                                    strokeWidth={5}
-                                >
-                                    <Label
-                                        content={({ viewBox }) => {
-                                            if (
-                                                viewBox &&
-                                                'cx' in viewBox &&
-                                                'cy' in viewBox
-                                            ) {
-                                                return (
-                                                    <text
-                                                        x={viewBox.cx}
-                                                        y={viewBox.cy}
-                                                        textAnchor="middle"
-                                                        dominantBaseline="middle"
-                                                    >
-                                                        <tspan
+                        {isLoading ? (
+                            <Skeleton className="h-full w-full rounded-full" />
+                        ) : (
+                            <ChartContainer
+                                config={specimenChartConfig}
+                                className="h-full w-full"
+                            >
+                                <PieChart>
+                                    <ChartTooltip
+                                        cursor={false}
+                                        content={
+                                            <ChartTooltipContent
+                                                className="min-w-45"
+                                                indicator="line"
+                                            />
+                                        }
+                                    />
+                                    <Pie
+                                        data={specimenCountsByClass.map(
+                                            ({
+                                                specimenClass,
+                                                specimenCount,
+                                            }) => ({
+                                                specimenClass,
+                                                specimenCount,
+                                                fill: specimenChartConfig[
+                                                    specimenClass
+                                                ]?.color,
+                                            }),
+                                        )}
+                                        nameKey="specimenClass"
+                                        dataKey="specimenCount"
+                                        innerRadius={60}
+                                        outerRadius={80}
+                                        strokeWidth={5}
+                                    >
+                                        <Label
+                                            content={({ viewBox }) => {
+                                                if (
+                                                    viewBox &&
+                                                    'cx' in viewBox &&
+                                                    'cy' in viewBox
+                                                ) {
+                                                    return (
+                                                        <text
                                                             x={viewBox.cx}
                                                             y={viewBox.cy}
-                                                            className="fill-foreground text-3xl font-bold"
+                                                            textAnchor="middle"
+                                                            dominantBaseline="middle"
                                                         >
-                                                            {totalSpecimenCount.toLocaleString()}
-                                                        </tspan>
-                                                        <tspan
-                                                            x={viewBox.cx}
-                                                            y={
-                                                                (viewBox.cy ||
-                                                                    0) + 24
-                                                            }
-                                                            className="fill-muted-foreground"
-                                                        >
-                                                            Specimens
-                                                        </tspan>
-                                                    </text>
-                                                );
-                                            }
-                                        }}
-                                    />
-                                </Pie>
-                            </PieChart>
-                        </ChartContainer>
-                    </div>
-                    <div className="h-72 w-full min-w-0 flex-1">
-                        <ChartContainer
-                            config={specimenChartConfig}
-                            className="h-full w-full"
-                        >
-                            {chartType === 'bar' ? (
-                                <BarChart
-                                    data={specimenCountsByMonth}
-                                    margin={chartMargins}
-                                >
-                                    {chartAxes}
-                                    {specimenClasses.map(specimenClass => (
-                                        <Bar
-                                            key={specimenClass}
-                                            dataKey={specimenClass}
-                                            stackId="specimens"
-                                            fill={
-                                                specimenChartConfig[
-                                                    specimenClass
-                                                ]?.color
-                                            }
-                                            stroke={
-                                                specimenChartConfig[
-                                                    specimenClass
-                                                ]?.color
-                                            }
-                                            fillOpacity={0.75}
-                                            strokeWidth={1}
-                                        />
-                                    ))}
-                                    {chartLegend}
-                                </BarChart>
-                            ) : (
-                                <AreaChart
-                                    data={specimenCountsByMonth}
-                                    margin={chartMargins}
-                                >
-                                    {chartAxes}
-                                    {specimenClasses.map(specimenClass => (
-                                        <Area
-                                            key={specimenClass}
-                                            type="monotone"
-                                            dataKey={specimenClass}
-                                            fill={
-                                                specimenChartConfig[
-                                                    specimenClass
-                                                ]?.color
-                                            }
-                                            stroke={
-                                                specimenChartConfig[
-                                                    specimenClass
-                                                ]?.color
-                                            }
-                                            fillOpacity={0.2}
-                                            strokeWidth={3}
-                                            dot={{
-                                                r: 2,
-                                                fillOpacity: 1,
+                                                            <tspan
+                                                                x={viewBox.cx}
+                                                                y={viewBox.cy}
+                                                                className="fill-foreground text-3xl font-bold"
+                                                            >
+                                                                {totalSpecimenCount.toLocaleString()}
+                                                            </tspan>
+                                                            <tspan
+                                                                x={viewBox.cx}
+                                                                y={
+                                                                    (viewBox.cy ||
+                                                                        0) + 24
+                                                                }
+                                                                className="fill-muted-foreground"
+                                                            >
+                                                                Specimens
+                                                            </tspan>
+                                                        </text>
+                                                    );
+                                                }
                                             }}
                                         />
-                                    ))}
-                                    {chartLegend}
-                                </AreaChart>
-                            )}
-                        </ChartContainer>
+                                    </Pie>
+                                </PieChart>
+                            </ChartContainer>
+                        )}
+                    </div>
+                    <div className="h-72 w-full min-w-0 flex-1">
+                        {isLoading ? (
+                            <Skeleton className="h-full w-full" />
+                        ) : (
+                            <ChartContainer
+                                config={specimenChartConfig}
+                                className="h-full w-full"
+                            >
+                                {chartType === 'bar' ? (
+                                    <BarChart
+                                        data={specimenCountsByMonth}
+                                        margin={chartMargins}
+                                    >
+                                        {chartAxes}
+                                        {specimenClasses.map(specimenClass => (
+                                            <Bar
+                                                key={specimenClass}
+                                                dataKey={specimenClass}
+                                                stackId="specimens"
+                                                fill={
+                                                    specimenChartConfig[
+                                                        specimenClass
+                                                    ]?.color
+                                                }
+                                                stroke={
+                                                    specimenChartConfig[
+                                                        specimenClass
+                                                    ]?.color
+                                                }
+                                                fillOpacity={0.75}
+                                                strokeWidth={1}
+                                            />
+                                        ))}
+                                        {chartLegend}
+                                    </BarChart>
+                                ) : (
+                                    <AreaChart
+                                        data={specimenCountsByMonth}
+                                        margin={chartMargins}
+                                    >
+                                        {chartAxes}
+                                        {specimenClasses.map(specimenClass => (
+                                            <Area
+                                                key={specimenClass}
+                                                type="monotone"
+                                                dataKey={specimenClass}
+                                                fill={
+                                                    specimenChartConfig[
+                                                        specimenClass
+                                                    ]?.color
+                                                }
+                                                stroke={
+                                                    specimenChartConfig[
+                                                        specimenClass
+                                                    ]?.color
+                                                }
+                                                fillOpacity={0.2}
+                                                strokeWidth={3}
+                                                dot={{
+                                                    r: 2,
+                                                    fillOpacity: 1,
+                                                }}
+                                            />
+                                        ))}
+                                        {chartLegend}
+                                    </AreaChart>
+                                )}
+                            </ChartContainer>
+                        )}
                     </div>
                 </div>
             </CardContent>

--- a/src/features/operations/specimen-composition/components/operations-specimen-composition.tsx
+++ b/src/features/operations/specimen-composition/components/operations-specimen-composition.tsx
@@ -23,6 +23,8 @@ import { useMemo } from 'react';
 import { useOperationsFilters } from '@/features/operations/view-state/use-operations-filters';
 import { Label } from '@/components/ui/label';
 import { useTranslations } from 'next-intl';
+import { SkeletonList } from '@/components/ui/skeleton-list';
+import EmptyBanner from '@/components/ui/empty-banner';
 
 const COMPOSITION_SECTIONS: {
     specimenClassificationAxis: SpecimenClassificationAxis;
@@ -72,11 +74,10 @@ export default function OperationsSpecimenComposition({
         return species.filter(speciesName => validOptions.has(speciesName));
     }, [selectedSpecies, speciesOptions]);
 
-    if (isGetMonthlySpecimensCountPending || !getMonthlySpecimensCountResult) {
-        return <h1>{t('monthlySpecimenCountsLoading')}</h1>;
-    }
+    const isLoading =
+        isGetMonthlySpecimensCountPending || !getMonthlySpecimensCountResult;
 
-    if (!getMonthlySpecimensCountResult.ok) {
+    if (!isLoading && !getMonthlySpecimensCountResult.ok) {
         return (
             <h1>
                 {t('monthlySpecimenCountsError')}
@@ -85,7 +86,9 @@ export default function OperationsSpecimenComposition({
         );
     }
 
-    const monthlySpecimenCounts = getMonthlySpecimensCountResult.data.data;
+    const monthlySpecimenCounts = getMonthlySpecimensCountResult?.ok
+        ? getMonthlySpecimensCountResult.data.data
+        : undefined;
 
     return (
         <div className="space-y-6">
@@ -99,7 +102,7 @@ export default function OperationsSpecimenComposition({
                         setFilters({ selectedSpecies: species })
                     }
                 >
-                    <MultiSelectTrigger>
+                    <MultiSelectTrigger disabled={isLoading}>
                         <MultiSelectValue placeholder={t('selectSpecies')} />
                     </MultiSelectTrigger>
                     <MultiSelectContent
@@ -118,35 +121,43 @@ export default function OperationsSpecimenComposition({
                     </MultiSelectContent>
                 </MultiSelect>
             </div>
-            {COMPOSITION_SECTIONS.map(
-                ({ specimenClassificationAxis, title }) => {
-                    const specimenCountsByClass = sumSpecimenCountsByClass(
-                        specimenClassificationAxis,
-                        monthlySpecimenCounts,
-                        validSelectedSpecies,
-                    );
-                    const specimenCountsByMonth = groupSpecimenCountsByMonth(
-                        specimenClassificationAxis,
-                        monthlySpecimenCounts,
-                        validSelectedSpecies,
-                    );
-                    const specimenChartConfig = buildSpecimenChartConfig(
-                        specimenClassificationAxis,
-                        specimenCountsByClass.map(
-                            ({ specimenClass }) => specimenClass,
-                        ),
-                    );
+            {isLoading ? (
+                <SkeletonList count={3} className="h-72" width="full" />
+            ) : validSelectedSpecies.length === 0 ? (
+                <EmptyBanner message={t('monthlySpecimenCountsEmpty')} />
+            ) : (
+                monthlySpecimenCounts &&
+                COMPOSITION_SECTIONS.map(
+                    ({ specimenClassificationAxis, title }) => {
+                        const specimenCountsByClass = sumSpecimenCountsByClass(
+                            specimenClassificationAxis,
+                            monthlySpecimenCounts,
+                            validSelectedSpecies,
+                        );
+                        const specimenCountsByMonth =
+                            groupSpecimenCountsByMonth(
+                                specimenClassificationAxis,
+                                monthlySpecimenCounts,
+                                validSelectedSpecies,
+                            );
+                        const specimenChartConfig = buildSpecimenChartConfig(
+                            specimenClassificationAxis,
+                            specimenCountsByClass.map(
+                                ({ specimenClass }) => specimenClass,
+                            ),
+                        );
 
-                    return (
-                        <CompositionChartPair
-                            key={specimenClassificationAxis}
-                            title={title}
-                            specimenCountsByClass={specimenCountsByClass}
-                            specimenCountsByMonth={specimenCountsByMonth}
-                            specimenChartConfig={specimenChartConfig}
-                        />
-                    );
-                },
+                        return (
+                            <CompositionChartPair
+                                key={specimenClassificationAxis}
+                                title={title}
+                                specimenCountsByClass={specimenCountsByClass}
+                                specimenCountsByMonth={specimenCountsByMonth}
+                                specimenChartConfig={specimenChartConfig}
+                            />
+                        );
+                    },
+                )
             )}
         </div>
     );

--- a/src/features/operations/specimen-composition/components/operations-specimen-composition.tsx
+++ b/src/features/operations/specimen-composition/components/operations-specimen-composition.tsx
@@ -122,7 +122,7 @@ export default function OperationsSpecimenComposition({
                 </MultiSelect>
             </div>
             {isLoading ? (
-                <SkeletonList count={3} className="h-72" width="full" />
+                <SkeletonList count={3} height="xxl" width="full" />
             ) : validSelectedSpecies.length === 0 ? (
                 <EmptyBanner message={t('monthlySpecimenCountsEmpty')} />
             ) : (

--- a/src/features/operations/specimen-composition/components/operations-specimen-composition.tsx
+++ b/src/features/operations/specimen-composition/components/operations-specimen-composition.tsx
@@ -154,7 +154,19 @@ export default function OperationsSpecimenComposition({
                 </div>
             </div>
             {isLoading ? (
-                <SkeletonList count={3} height="xxl" width="full" />
+                COMPOSITION_SECTIONS.map(
+                    ({ specimenClassificationAxis, title }) => (
+                        <CompositionChartPair
+                            key={specimenClassificationAxis}
+                            title={title}
+                            chartType={chartType}
+                            specimenCountsByClass={[]}
+                            specimenCountsByMonth={[]}
+                            specimenChartConfig={{}}
+                            isLoading={isLoading}
+                        />
+                    ),
+                )
             ) : validSelectedSpecies.length === 0 ? (
                 <EmptyBanner message={t('monthlySpecimenCountsEmpty')} />
             ) : (
@@ -187,6 +199,7 @@ export default function OperationsSpecimenComposition({
                                 specimenCountsByClass={specimenCountsByClass}
                                 specimenCountsByMonth={specimenCountsByMonth}
                                 specimenChartConfig={specimenChartConfig}
+                                isLoading={isLoading}
                             />
                         );
                     },

--- a/src/features/operations/specimen-composition/components/operations-specimen-composition.tsx
+++ b/src/features/operations/specimen-composition/components/operations-specimen-composition.tsx
@@ -23,7 +23,6 @@ import { useMemo, useState } from 'react';
 import { useOperationsFilters } from '@/features/operations/view-state/use-operations-filters';
 import { Label } from '@/components/ui/label';
 import { useTranslations } from 'next-intl';
-import { SkeletonList } from '@/components/ui/skeleton-list';
 import EmptyBanner from '@/components/ui/empty-banner';
 import { BarChart3, LineChart } from 'lucide-react';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';


### PR DESCRIPTION
* Geographical summary has the same loading state as before; updated devices to match specimens loading structure
* Specimen composition loads the three skeleton cards with a circle for the pie chart and a rectangle for the line/bar chart; please check if the rectangle shows up for h-full, because it disappears for anything larger than h-64 and I'm not sure if it's just my laptop
* AI performance has skeletons for missing information (coverage, reviewed specimens, accuracy) and skeletonLists for the table contents (confusion matrix, sensitivity/specificity) and displays any static content (interpretation)
* Field team performance is the same as before, except a small skeleton at the top was removed as it didn't fit with the card appearance