### PR TITLE
VCV-274: Error State - Operations

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -45,9 +45,9 @@
         "devices": "Devices",
         "uniqueSites": "Unique Sites",
         "noDeviceActivity": "No device activity to display.",
-        "deviceActivityError": "Failed to load device activity. Check the console for details.",
-        "countryError": "Failed to load country for this program.",
-        "specimenDataError": "Failed to load session data.",
+        "deviceActivityError": "Failed to load device activity. Please try again later or contact support.",
+        "countryError": "Failed to load country for this program. Please try again later or contact support.",
+        "specimenDataError": "Failed to load session data. Please try again later or contact support.",
         "noSpecimenData": "No site data found for the selected filters.",
         "active": "Active",
         "inactive": "Inactive",
@@ -77,7 +77,7 @@
         "anophelesNoData": "0 / No data"
     },
     "OperationsSpecimenComposition": {
-        "monthlySpecimenCountsError": "There was a problem fetching the specimen counts. Please try again later or contact support.",
+        "monthlySpecimenCountsError": "Failed to load specimen counts. Please try again later or contact support.",
         "monthlySpecimenCountsEmpty": "No specimens found for this date range and species filter.",
         "filterBySpecies": "Filter by Species",
         "selectSpecies": "Select species...",

--- a/messages/en.json
+++ b/messages/en.json
@@ -122,6 +122,7 @@
     "OperationsInterventionMetrics": {
         "interventionMetricsTitle": "Intervention Coverage Metrics",
         "interventionMetricsDescription": "Bednet coverage across surveyed households for the selected locations and date range.",
+        "failedToLoad": "Failed to load intervention metrics. Please try again later or contact support.",
         "netUsageTitle": "Net Usage Rate",
         "netUsageSubtitle": "{peopleUnderNet} of {peopleSurveyed} people surveyed slept under a net",
         "noLlinsDistributed": "No nets distributed in this district",

--- a/messages/en.json
+++ b/messages/en.json
@@ -96,6 +96,7 @@
         "accuracy": "Accuracy",
         "correctOf": "{numCorrect} correct of {total} {category} comparisons",
         "noConfusionMatrixData": "No verified {category} comparisons in this date range; there are no annotations to compare with VectorCam's predictions.",
+        "failedToLoad": "Failed to load annotations summary. Please try again later or contact support.",
         "perLabelMetrics": "Per-Label Metrics",
         "label": "Label",
         "sensitivity": "Sensitivity",
@@ -114,6 +115,7 @@
         "activeCollectors": "Active Collectors",
         "submittedThisOrLastMonth": "Submitted this or last month",
         "noSubmissionsFound": "No submissions found for this location and date range.",
+        "failedToLoad": "Failed to load sessions. Please try again later or contact support.",
         "collector": "Collector",
         "session": "session"
     },

--- a/src/components/ui/stat-card-skeleton.tsx
+++ b/src/components/ui/stat-card-skeleton.tsx
@@ -1,0 +1,12 @@
+import { Skeleton, type SkeletonProps } from './skeleton';
+
+function StatCardSkeleton({ variant }: SkeletonProps) {
+    return (
+        <div className="space-y-2 py-2">
+            <Skeleton width="sm" height="xl" variant={variant} />
+            <Skeleton width="lg" height="sm" variant={variant} />
+        </div>
+    );
+}
+
+export { StatCardSkeleton };

--- a/src/features/operations/ai-performance/components/operations-ai-performance.tsx
+++ b/src/features/operations/ai-performance/components/operations-ai-performance.tsx
@@ -9,6 +9,7 @@ import { Fragment } from 'react/jsx-runtime';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useTranslations } from 'next-intl';
 import ErrorBanner from '@/components/ui/error-banner';
+import { cn } from '@/utils/cn';
 
 interface OperationsAiPerformanceProps {
     siteIds: number[];
@@ -66,7 +67,12 @@ export default function OperationsAiPerformance({
 
             <div className="grid gap-3 lg:col-span-2 lg:grid-cols-2">
                 <Fragment>
-                    <Card className="border-success/40 bg-success/5 gap-0 py-0">
+                    <Card
+                        className={cn(
+                            !isError && 'border-success/40 bg-success/5',
+                            'gap-0 py-0',
+                        )}
+                    >
                         <CardContent className="p-4">
                             <p className="text-muted-foreground text-sm">
                                 {t('coverage')}

--- a/src/features/operations/ai-performance/components/operations-ai-performance.tsx
+++ b/src/features/operations/ai-performance/components/operations-ai-performance.tsx
@@ -6,10 +6,10 @@ import { Card, CardContent } from '@/components/ui/card';
 import SpecimenConfusionMatrix from './specimen-confusion-matrix';
 import { Info } from 'lucide-react';
 import { Fragment } from 'react/jsx-runtime';
-import { Skeleton } from '@/components/ui/skeleton';
 import { useTranslations } from 'next-intl';
 import ErrorBanner from '@/components/ui/error-banner';
 import { cn } from '@/utils/cn';
+import { StatCardSkeleton } from '@/components/ui/stat-card-skeleton';
 
 interface OperationsAiPerformanceProps {
     siteIds: number[];
@@ -78,22 +78,11 @@ export default function OperationsAiPerformance({
                                 {t('coverage')}
                             </p>
                             {isLoading || isError ? (
-                                <div className="space-y-2 py-2">
-                                    <Skeleton
-                                        width="sm"
-                                        height="xl"
-                                        variant={
-                                            isError ? 'destructive' : 'default'
-                                        }
-                                    />
-                                    <Skeleton
-                                        width="lg"
-                                        height="sm"
-                                        variant={
-                                            isError ? 'destructive' : 'default'
-                                        }
-                                    />
-                                </div>
+                                <StatCardSkeleton
+                                    variant={
+                                        isError ? 'destructive' : 'default'
+                                    }
+                                />
                             ) : (
                                 <Fragment>
                                     <p className="mt-1 text-4xl font-semibold tracking-tight">
@@ -119,22 +108,11 @@ export default function OperationsAiPerformance({
                                 {t('reviewedSpecimens')}
                             </p>
                             {isLoading || isError ? (
-                                <div className="space-y-2 py-2">
-                                    <Skeleton
-                                        width="sm"
-                                        height="xl"
-                                        variant={
-                                            isError ? 'destructive' : 'default'
-                                        }
-                                    />
-                                    <Skeleton
-                                        width="lg"
-                                        height="sm"
-                                        variant={
-                                            isError ? 'destructive' : 'default'
-                                        }
-                                    />
-                                </div>
+                                <StatCardSkeleton
+                                    variant={
+                                        isError ? 'destructive' : 'default'
+                                    }
+                                />
                             ) : (
                                 <Fragment>
                                     <p className="mt-1 text-4xl font-semibold tracking-tight">

--- a/src/features/operations/ai-performance/components/operations-ai-performance.tsx
+++ b/src/features/operations/ai-performance/components/operations-ai-performance.tsx
@@ -8,6 +8,7 @@ import { Info } from 'lucide-react';
 import { Fragment } from 'react/jsx-runtime';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useTranslations } from 'next-intl';
+import ErrorBanner from '@/components/ui/error-banner';
 
 interface OperationsAiPerformanceProps {
     siteIds: number[];
@@ -34,15 +35,7 @@ export default function OperationsAiPerformance({
 
     const isLoading =
         isGetAnnotationsSummaryPending || !getAnnotationsSummaryResult;
-
-    if (!isLoading && !getAnnotationsSummaryResult.ok) {
-        return (
-            <p className="text-destructive text-sm">
-                {getAnnotationsSummaryResult.error.message ??
-                    'Failed to load annotations summary.'}
-            </p>
-        );
-    }
+    const isError = !isLoading && !getAnnotationsSummaryResult.ok;
 
     const annotationsSummary = getAnnotationsSummaryResult?.ok
         ? getAnnotationsSummaryResult.data
@@ -62,10 +55,14 @@ export default function OperationsAiPerformance({
 
     return (
         <div className="space-y-4">
-            <div className="border-accent bg-accent/40 text-accent-foreground flex items-center gap-2 rounded-lg border px-4 py-3 text-sm">
-                <Info className="h-4 w-4" />
-                <span>{t('coverageReflects')}</span>
-            </div>
+            {isError ? (
+                <ErrorBanner message={t('failedToLoad')} />
+            ) : (
+                <div className="border-accent bg-accent/40 text-accent-foreground flex items-center gap-2 rounded-lg border px-4 py-3 text-sm">
+                    <Info className="h-4 w-4" />
+                    <span>{t('coverageReflects')}</span>
+                </div>
+            )}
 
             <div className="grid gap-3 lg:col-span-2 lg:grid-cols-2">
                 <Fragment>
@@ -74,10 +71,22 @@ export default function OperationsAiPerformance({
                             <p className="text-muted-foreground text-sm">
                                 {t('coverage')}
                             </p>
-                            {isLoading ? (
+                            {isLoading || isError ? (
                                 <div className="space-y-2 py-2">
-                                    <Skeleton width="sm" height="xl" />
-                                    <Skeleton width="lg" height="sm" />
+                                    <Skeleton
+                                        width="sm"
+                                        height="xl"
+                                        variant={
+                                            isError ? 'destructive' : 'default'
+                                        }
+                                    />
+                                    <Skeleton
+                                        width="lg"
+                                        height="sm"
+                                        variant={
+                                            isError ? 'destructive' : 'default'
+                                        }
+                                    />
                                 </div>
                             ) : (
                                 <Fragment>
@@ -103,10 +112,22 @@ export default function OperationsAiPerformance({
                             <p className="text-muted-foreground text-sm">
                                 {t('reviewedSpecimens')}
                             </p>
-                            {isLoading ? (
+                            {isLoading || isError ? (
                                 <div className="space-y-2 py-2">
-                                    <Skeleton width="sm" height="xl" />
-                                    <Skeleton width="lg" height="sm" />
+                                    <Skeleton
+                                        width="sm"
+                                        height="xl"
+                                        variant={
+                                            isError ? 'destructive' : 'default'
+                                        }
+                                    />
+                                    <Skeleton
+                                        width="lg"
+                                        height="sm"
+                                        variant={
+                                            isError ? 'destructive' : 'default'
+                                        }
+                                    />
                                 </div>
                             ) : (
                                 <Fragment>
@@ -139,6 +160,7 @@ export default function OperationsAiPerformance({
                         annotationsSummary?.confusionMatrices?.species
                     }
                     isLoading={isLoading}
+                    isError={isError}
                 />
 
                 <SpecimenConfusionMatrix
@@ -148,6 +170,7 @@ export default function OperationsAiPerformance({
                     predictionAxisLabel="VectorCam Sex Label"
                     confusionMatrix={annotationsSummary?.confusionMatrices?.sex}
                     isLoading={isLoading}
+                    isError={isError}
                 />
 
                 <SpecimenConfusionMatrix
@@ -159,6 +182,7 @@ export default function OperationsAiPerformance({
                         annotationsSummary?.confusionMatrices?.abdomenStatus
                     }
                     isLoading={isLoading}
+                    isError={isError}
                 />
             </div>
         </div>

--- a/src/features/operations/ai-performance/components/specimen-confusion-matrix.tsx
+++ b/src/features/operations/ai-performance/components/specimen-confusion-matrix.tsx
@@ -162,7 +162,12 @@ export default function SpecimenConfusionMatrix({
             </CardHeader>
 
             <CardContent className="space-y-6">
-                <div className="border-secondary/30 bg-secondary/5 rounded-lg border p-4">
+                <div
+                    className={cn(
+                        !isError && 'border-secondary/30 bg-secondary/5',
+                        'rounded-lg border p-4',
+                    )}
+                >
                     <p className="text-muted-foreground text-sm">
                         {t('accuracy')}
                     </p>

--- a/src/features/operations/ai-performance/components/specimen-confusion-matrix.tsx
+++ b/src/features/operations/ai-performance/components/specimen-confusion-matrix.tsx
@@ -17,8 +17,8 @@ import { cn } from '@/utils/cn';
 import { Bot } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Fragment } from 'react/jsx-runtime';
-import { Skeleton } from '@/components/ui/skeleton';
 import { SkeletonList } from '@/components/ui/skeleton-list';
+import { StatCardSkeleton } from '@/components/ui/stat-card-skeleton';
 
 const EXCLUDED_LABELS = ['unknown', 'Cannot be Determined'] as const;
 
@@ -172,18 +172,9 @@ export default function SpecimenConfusionMatrix({
                         {t('accuracy')}
                     </p>
                     {isLoading || isError ? (
-                        <div className="space-y-2 py-2">
-                            <Skeleton
-                                width="sm"
-                                height="xl"
-                                variant={isError ? 'destructive' : 'default'}
-                            />
-                            <Skeleton
-                                width="lg"
-                                height="sm"
-                                variant={isError ? 'destructive' : 'default'}
-                            />
-                        </div>
+                        <StatCardSkeleton
+                            variant={isError ? 'destructive' : 'default'}
+                        />
                     ) : (
                         <Fragment>
                             <p className="mt-1 text-4xl font-semibold tracking-tight">

--- a/src/features/operations/ai-performance/components/specimen-confusion-matrix.tsx
+++ b/src/features/operations/ai-performance/components/specimen-confusion-matrix.tsx
@@ -29,6 +29,7 @@ interface SpecimenConfusionMatrixProps {
     predictionAxisLabel: string;
     confusionMatrix: AnnotationConfusionMatrix | undefined;
     isLoading: boolean;
+    isError: boolean;
 }
 
 export default function SpecimenConfusionMatrix({
@@ -38,6 +39,7 @@ export default function SpecimenConfusionMatrix({
     predictionAxisLabel,
     confusionMatrix,
     isLoading,
+    isError,
 }: SpecimenConfusionMatrixProps) {
     const t = useTranslations('OperationsAIPerformance');
 
@@ -164,10 +166,18 @@ export default function SpecimenConfusionMatrix({
                     <p className="text-muted-foreground text-sm">
                         {t('accuracy')}
                     </p>
-                    {isLoading ? (
+                    {isLoading || isError ? (
                         <div className="space-y-2 py-2">
-                            <Skeleton width="sm" height="xl" />
-                            <Skeleton width="lg" height="sm" />
+                            <Skeleton
+                                width="sm"
+                                height="xl"
+                                variant={isError ? 'destructive' : 'default'}
+                            />
+                            <Skeleton
+                                width="lg"
+                                height="sm"
+                                variant={isError ? 'destructive' : 'default'}
+                            />
                         </div>
                     ) : (
                         <Fragment>
@@ -193,7 +203,7 @@ export default function SpecimenConfusionMatrix({
                     <Table className="min-w-180 table-fixed border-collapse overflow-hidden rounded-lg">
                         <TableHeader>
                             <TableRow className="hover:bg-transparent">
-                                {!isLoading && (
+                                {!isLoading && !isError && (
                                     <TableHead className="bg-muted/40 h-12 w-60 border" />
                                 )}
                                 <TableHead
@@ -203,7 +213,7 @@ export default function SpecimenConfusionMatrix({
                                     {predictionAxisLabel}
                                 </TableHead>
                             </TableRow>
-                            {!isLoading && (
+                            {!isLoading && !isError && (
                                 <TableRow className="hover:bg-transparent">
                                     <TableHead className="bg-muted/20 h-auto border px-3 py-3 text-center text-sm leading-snug font-semibold wrap-break-word whitespace-normal">
                                         {groundTruthAxisLabel}
@@ -222,7 +232,7 @@ export default function SpecimenConfusionMatrix({
                             )}
                         </TableHeader>
 
-                        {!isLoading && (
+                        {!isLoading && !isError && (
                             <TableBody>
                                 {classLabels.map(groundTruthLabel => {
                                     const groundTruthLabelTotal =
@@ -286,8 +296,13 @@ export default function SpecimenConfusionMatrix({
                             </TableBody>
                         )}
                     </Table>
-                    {isLoading && (
-                        <SkeletonList count={3} width="full" height="xxl" />
+                    {(isLoading || isError) && (
+                        <SkeletonList
+                            count={3}
+                            width="full"
+                            height="xxl"
+                            variant={isError ? 'destructive' : 'default'}
+                        />
                     )}
                 </div>
 
@@ -317,6 +332,7 @@ export default function SpecimenConfusionMatrix({
 
                             <TableBody>
                                 {!isLoading &&
+                                    !isError &&
                                     filteredClassLabels.map(classLabel => {
                                         const truePositives =
                                             getSpecimenCountForCell(
@@ -375,10 +391,15 @@ export default function SpecimenConfusionMatrix({
                                     })}
                             </TableBody>
                         </Table>
-                        {isLoading && (
-                            <SkeletonList count={3} height="lg" width="full" />
+                        {(isLoading || isError) && (
+                            <SkeletonList
+                                count={3}
+                                height="lg"
+                                width="full"
+                                variant={isError ? 'destructive' : 'default'}
+                            />
                         )}
-                        {!isLoading && (
+                        {!isLoading && !isError && (
                             <p className="text-muted-foreground text-sm leading-6">
                                 {excludedSpecimenCounts.map(
                                     ({ excludedLabel, count }) => {

--- a/src/features/operations/ai-performance/components/specimen-confusion-matrix.tsx
+++ b/src/features/operations/ai-performance/components/specimen-confusion-matrix.tsx
@@ -98,7 +98,7 @@ export default function SpecimenConfusionMatrix({
         0,
     );
 
-    if (!isLoading && totalSpecimensInMatrix === 0) {
+    if (!isLoading && !isError && totalSpecimensInMatrix === 0) {
         return (
             <Card className="gap-0 lg:col-span-2">
                 <CardContent className="space-y-6">

--- a/src/features/operations/field-user-compliance/components/operations-field-user-compliance.tsx
+++ b/src/features/operations/field-user-compliance/components/operations-field-user-compliance.tsx
@@ -6,6 +6,8 @@ import { buildFieldUserComplianceData } from '@/features/operations/field-user-c
 import { eachMonthOfInterval, format, parseISO } from 'date-fns';
 import { useMemo } from 'react';
 import FieldUserComplianceChart from '@/features/operations/field-user-compliance/components/field-user-compliance-chart';
+import { useTranslations } from 'next-intl';
+import ErrorBanner from '@/components/ui/error-banner';
 
 interface OperationsFieldUserComplianceProps {
     siteIds: number[];
@@ -20,6 +22,7 @@ export default function OperationsFieldUserCompliance({
     startDate,
     endDate,
 }: OperationsFieldUserComplianceProps) {
+    const t = useTranslations('OperationsFieldTeamPerformance');
     const { data: getAllSessionsResult, isPending } = useGetAllSessions({
         siteIds,
         startDate,
@@ -48,9 +51,10 @@ export default function OperationsFieldUserCompliance({
 
     if (!getAllSessionsResult.ok) {
         return (
-            <p className="text-destructive text-sm">
-                {getAllSessionsResult.error.message}
-            </p>
+            <div className="space-y-4">
+                <ErrorBanner message={t('failedToLoad')} />
+                <Skeleton className="h-64 w-full" variant="destructive" />
+            </div>
         );
     }
 

--- a/src/features/operations/geographical-summary/components/device-view.tsx
+++ b/src/features/operations/geographical-summary/components/device-view.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/features/operations/geographical-summary/utils/device-marker-helpers';
 import { useCountry } from '@/features/operations/geographical-summary/context/country-context';
 import type { Site } from '@/api/site/validation/site-schema';
+import ErrorBanner from '@/components/ui/error-banner';
 
 const DeviceMap = dynamic(() => import('./device-map'), { ssr: false });
 
@@ -72,6 +73,7 @@ export default function DeviceView({
 
     return (
         <div className="space-y-3">
+            {isError && <ErrorBanner message={t('deviceActivityError')} />}
             <div className="flex flex-wrap gap-3">
                 {tiers.map(tier => (
                     <Card key={tier.key} className="border-border/50 w-fit">
@@ -79,8 +81,13 @@ export default function DeviceView({
                             <p className="text-muted-foreground text-xs">
                                 {t(tier.key)}
                             </p>
-                            {isPending ? (
-                                <Skeleton className="h-5 w-8" />
+                            {isPending || isError ? (
+                                <Skeleton
+                                    className="h-5 w-8"
+                                    variant={
+                                        isError ? 'destructive' : 'default'
+                                    }
+                                />
                             ) : (
                                 <p className="text-lg leading-none font-bold">
                                     {tier.count}
@@ -93,12 +100,11 @@ export default function DeviceView({
 
             <Card className="border-border/50 p-0">
                 <CardContent className="relative h-125 p-0">
-                    {isPending ? (
-                        <Skeleton className="h-full w-full rounded-md" />
-                    ) : isError ? (
-                        <p className="text-muted-foreground flex h-125 items-center justify-center p-0 text-sm">
-                            {t('deviceActivityError')}
-                        </p>
+                    {isPending || isError ? (
+                        <Skeleton
+                            className="h-full w-full rounded-md"
+                            variant={isError ? 'destructive' : 'default'}
+                        />
                     ) : !deviceMarkers ||
                       deviceCounts.active + deviceCounts.inactive === 0 ? (
                         <div className="text-muted-foreground flex h-full items-center justify-center text-sm">

--- a/src/features/operations/geographical-summary/components/device-view.tsx
+++ b/src/features/operations/geographical-summary/components/device-view.tsx
@@ -57,16 +57,6 @@ export default function DeviceView({
         );
     }, [deviceActivity, descendantsOfSelectedLocations, country]);
 
-    if (isError) {
-        return (
-            <Card className="border-border/50 p-0">
-                <CardContent className="text-muted-foreground flex h-125 items-center justify-center p-0 text-sm">
-                    {t('deviceActivityError')}
-                </CardContent>
-            </Card>
-        );
-    }
-
     const deviceCounts = deviceMarkers?.reduce(
         (counts, marker) => ({
             active: counts.active + marker.activeDeviceCount,
@@ -105,6 +95,10 @@ export default function DeviceView({
                 <CardContent className="relative h-125 p-0">
                     {isPending ? (
                         <Skeleton className="h-full w-full rounded-md" />
+                    ) : isError ? (
+                        <p className="text-muted-foreground flex h-125 items-center justify-center p-0 text-sm">
+                            {t('deviceActivityError')}
+                        </p>
                     ) : !deviceMarkers ||
                       deviceCounts.active + deviceCounts.inactive === 0 ? (
                         <div className="text-muted-foreground flex h-full items-center justify-center text-sm">

--- a/src/features/operations/geographical-summary/components/device-view.tsx
+++ b/src/features/operations/geographical-summary/components/device-view.tsx
@@ -121,46 +121,49 @@ export default function DeviceView({
                 </CardContent>
             </Card>
 
-            <div className="text-muted-foreground flex flex-wrap items-start gap-8 text-xs">
-                <div className="space-y-1.5">
-                    <p className="text-foreground font-medium">
-                        {t('legendMarkerTitle')}
-                    </p>
-                    <p>{t('legendMarkerSubtitle')}</p>
-                </div>
-                <div className="space-y-1.5">
-                    <p className="text-foreground font-medium">
-                        {t('legendSizeTitle')}
-                    </p>
-                    <p>{t('legendSizeSubtitle')}</p>
-                </div>
-                <div className="space-y-1.5">
-                    <p className="text-foreground font-medium">
-                        {t('legendColorTitle')}
-                    </p>
-                    <div className="flex flex-wrap gap-3">
-                        <span className="flex items-center gap-1.5">
-                            <span
-                                className="inline-block h-3 w-3 rounded-full"
-                                style={{
-                                    backgroundColor: DEVICE_HEALTH_COLOR.active,
-                                }}
-                            />
-                            {t('legendActive')}
-                        </span>
-                        <span className="flex items-center gap-1.5">
-                            <span
-                                className="inline-block h-3 w-3 rounded-full"
-                                style={{
-                                    backgroundColor:
-                                        DEVICE_HEALTH_COLOR.inactive,
-                                }}
-                            />
-                            {t('legendInactive')}
-                        </span>
+            {!isPending && !isError && (
+                <div className="text-muted-foreground flex flex-wrap items-start gap-8 text-xs">
+                    <div className="space-y-1.5">
+                        <p className="text-foreground font-medium">
+                            {t('legendMarkerTitle')}
+                        </p>
+                        <p>{t('legendMarkerSubtitle')}</p>
+                    </div>
+                    <div className="space-y-1.5">
+                        <p className="text-foreground font-medium">
+                            {t('legendSizeTitle')}
+                        </p>
+                        <p>{t('legendSizeSubtitle')}</p>
+                    </div>
+                    <div className="space-y-1.5">
+                        <p className="text-foreground font-medium">
+                            {t('legendColorTitle')}
+                        </p>
+                        <div className="flex flex-wrap gap-3">
+                            <span className="flex items-center gap-1.5">
+                                <span
+                                    className="inline-block h-3 w-3 rounded-full"
+                                    style={{
+                                        backgroundColor:
+                                            DEVICE_HEALTH_COLOR.active,
+                                    }}
+                                />
+                                {t('legendActive')}
+                            </span>
+                            <span className="flex items-center gap-1.5">
+                                <span
+                                    className="inline-block h-3 w-3 rounded-full"
+                                    style={{
+                                        backgroundColor:
+                                            DEVICE_HEALTH_COLOR.inactive,
+                                    }}
+                                />
+                                {t('legendInactive')}
+                            </span>
+                        </div>
                     </div>
                 </div>
-            </div>
+            )}
         </div>
     );
 }

--- a/src/features/operations/geographical-summary/components/operations-geographical-summary.tsx
+++ b/src/features/operations/geographical-summary/components/operations-geographical-summary.tsx
@@ -35,11 +35,11 @@ export default function OperationsGeographicalSummary({
     selectedMarkerId,
     setSelectedMarkerId,
 }: OperationsGeographicalSummaryProps) {
-    const {
-        data: getProgramsResult,
-        isPending: isProgramsPending,
-        isError: isProgramsError,
-    } = useGetPrograms();
+    const { data: getProgramsResult, isPending: isProgramsPending } =
+        useGetPrograms();
+
+    const isLoading = isProgramsPending || !getProgramsResult;
+    const isError = !isLoading && !getProgramsResult.ok;
 
     const country = getProgramsResult?.ok
         ? getProgramsResult.data.programs.find(
@@ -72,7 +72,7 @@ export default function OperationsGeographicalSummary({
         </Tabs>
     );
 
-    if (isProgramsPending) {
+    if (isLoading) {
         return (
             <div className="mt-4 space-y-3">
                 {tabs}
@@ -81,7 +81,7 @@ export default function OperationsGeographicalSummary({
         );
     }
 
-    if (isProgramsError || !country) {
+    if (isError || !country) {
         return (
             <div className="mt-4 space-y-3">
                 {tabs}

--- a/src/features/operations/geographical-summary/components/operations-geographical-summary.tsx
+++ b/src/features/operations/geographical-summary/components/operations-geographical-summary.tsx
@@ -14,6 +14,7 @@ import {
     GEOGRAPHICAL_VIEWS,
     type GeographicalView,
 } from '@/features/operations/geographical-summary/utils/geographical-summary-helpers';
+import ErrorBanner from '@/components/ui/error-banner';
 
 interface OperationsGeographicalSummaryProps {
     programId: number;
@@ -84,7 +85,11 @@ export default function OperationsGeographicalSummary({
         return (
             <div className="mt-4 space-y-3">
                 {tabs}
-                <p className="text-destructive text-sm">{t('countryError')}</p>
+                <ErrorBanner message={t('countryError')} />
+                <Skeleton
+                    className="h-125 w-full rounded-md"
+                    variant="destructive"
+                />
             </div>
         );
     }

--- a/src/features/operations/geographical-summary/components/specimens-view.tsx
+++ b/src/features/operations/geographical-summary/components/specimens-view.tsx
@@ -11,6 +11,7 @@ import {
     ANOPHELES_COLOR,
     ANOPHELES_THRESHOLD,
 } from '@/features/operations/geographical-summary/utils/geographical-summary-helpers';
+import ErrorBanner from '@/components/ui/error-banner';
 
 const SiteMap = dynamic(() => import('./site-map'), { ssr: false });
 
@@ -47,13 +48,17 @@ export default function SpecimensView({
 
     return (
         <Fragment>
+            {isError && <ErrorBanner message={t('specimenDataError')} />}
             <Card className="border-border/50 w-fit">
                 <CardContent className="flex items-center gap-3 px-4">
                     <p className="text-muted-foreground text-xs">
                         {t('uniqueSites')}
                     </p>
-                    {isPending ? (
-                        <Skeleton className="h-5 w-8" />
+                    {isPending || isError ? (
+                        <Skeleton
+                            className="h-5 w-8"
+                            variant={isError ? 'destructive' : 'default'}
+                        />
                     ) : (
                         <p className="text-lg leading-none font-bold">
                             {totalSites}
@@ -71,16 +76,15 @@ export default function SpecimensView({
                             selectedMarkerId={selectedMarkerId}
                             onMarkerSelect={setSelectedMarkerId}
                         />
-                    ) : isError ? (
-                        <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
-                            {t('specimenDataError')}
-                        </div>
-                    ) : !isPending && markers.length === 0 ? (
+                    ) : !isPending && !isError && markers.length === 0 ? (
                         <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
                             {t('noSpecimenData')}
                         </div>
                     ) : (
-                        <Skeleton className="h-full w-full rounded-md" />
+                        <Skeleton
+                            className="h-full w-full rounded-md"
+                            variant={isError ? 'destructive' : 'default'}
+                        />
                     )}
                 </CardContent>
             </Card>

--- a/src/features/operations/geographical-summary/components/specimens-view.tsx
+++ b/src/features/operations/geographical-summary/components/specimens-view.tsx
@@ -69,7 +69,7 @@ export default function SpecimensView({
 
             <Card className="border-border/50 p-0">
                 <CardContent className="relative h-125 p-0">
-                    {siteMapMounted.current ? (
+                    {!isPending && !isError && siteMapMounted.current ? (
                         <SiteMap
                             markers={markers}
                             selectedLocations={selectedLocations}
@@ -89,74 +89,78 @@ export default function SpecimensView({
                 </CardContent>
             </Card>
 
-            <div className="text-muted-foreground flex flex-wrap items-start gap-8 text-xs">
-                <div className="space-y-1.5">
-                    <p className="text-foreground font-medium">
-                        {t('specimenLegendMarkerTitle')}
-                    </p>
-                    <p>{t('specimenLegendMarkerSubtitle')}</p>
-                </div>
-                <div className="space-y-1.5">
-                    <p className="text-foreground font-medium">
-                        {t('specimenLegendSizeTitle')}
-                    </p>
-                    <p>{t('specimenLegendSizeSubtitle')}</p>
-                </div>
-                <div className="space-y-1.5">
-                    <p className="text-foreground font-medium">
-                        {t('specimenLegendColorTitle')}
-                    </p>
-                    <div className="flex flex-wrap gap-3">
-                        <span className="flex items-center gap-1.5">
-                            <span
-                                className="inline-block h-3 w-3 rounded-full"
-                                style={{
-                                    backgroundColor: ANOPHELES_COLOR.none,
-                                }}
-                            />
-                            {t('anophelesNoData')}
-                        </span>
-                        <span className="flex items-center gap-1.5">
-                            <span
-                                className="inline-block h-3 w-3 rounded-full"
-                                style={{
-                                    backgroundColor: ANOPHELES_COLOR.low,
-                                }}
-                            />
-                            1-{ANOPHELES_THRESHOLD.low - 1}
-                        </span>
-                        <span className="flex items-center gap-1.5">
-                            <span
-                                className="inline-block h-3 w-3 rounded-full"
-                                style={{
-                                    backgroundColor: ANOPHELES_COLOR.moderate,
-                                }}
-                            />
-                            {ANOPHELES_THRESHOLD.low}-
-                            {ANOPHELES_THRESHOLD.moderate - 1}
-                        </span>
-                        <span className="flex items-center gap-1.5">
-                            <span
-                                className="inline-block h-3 w-3 rounded-full"
-                                style={{
-                                    backgroundColor: ANOPHELES_COLOR.high,
-                                }}
-                            />
-                            {ANOPHELES_THRESHOLD.moderate}-
-                            {ANOPHELES_THRESHOLD.high - 1}
-                        </span>
-                        <span className="flex items-center gap-1.5">
-                            <span
-                                className="inline-block h-3 w-3 rounded-full"
-                                style={{
-                                    backgroundColor: ANOPHELES_COLOR.critical,
-                                }}
-                            />
-                            {ANOPHELES_THRESHOLD.high}+
-                        </span>
+            {!isPending && !isError && (
+                <div className="text-muted-foreground flex flex-wrap items-start gap-8 text-xs">
+                    <div className="space-y-1.5">
+                        <p className="text-foreground font-medium">
+                            {t('specimenLegendMarkerTitle')}
+                        </p>
+                        <p>{t('specimenLegendMarkerSubtitle')}</p>
+                    </div>
+                    <div className="space-y-1.5">
+                        <p className="text-foreground font-medium">
+                            {t('specimenLegendSizeTitle')}
+                        </p>
+                        <p>{t('specimenLegendSizeSubtitle')}</p>
+                    </div>
+                    <div className="space-y-1.5">
+                        <p className="text-foreground font-medium">
+                            {t('specimenLegendColorTitle')}
+                        </p>
+                        <div className="flex flex-wrap gap-3">
+                            <span className="flex items-center gap-1.5">
+                                <span
+                                    className="inline-block h-3 w-3 rounded-full"
+                                    style={{
+                                        backgroundColor: ANOPHELES_COLOR.none,
+                                    }}
+                                />
+                                {t('anophelesNoData')}
+                            </span>
+                            <span className="flex items-center gap-1.5">
+                                <span
+                                    className="inline-block h-3 w-3 rounded-full"
+                                    style={{
+                                        backgroundColor: ANOPHELES_COLOR.low,
+                                    }}
+                                />
+                                1-{ANOPHELES_THRESHOLD.low - 1}
+                            </span>
+                            <span className="flex items-center gap-1.5">
+                                <span
+                                    className="inline-block h-3 w-3 rounded-full"
+                                    style={{
+                                        backgroundColor:
+                                            ANOPHELES_COLOR.moderate,
+                                    }}
+                                />
+                                {ANOPHELES_THRESHOLD.low}-
+                                {ANOPHELES_THRESHOLD.moderate - 1}
+                            </span>
+                            <span className="flex items-center gap-1.5">
+                                <span
+                                    className="inline-block h-3 w-3 rounded-full"
+                                    style={{
+                                        backgroundColor: ANOPHELES_COLOR.high,
+                                    }}
+                                />
+                                {ANOPHELES_THRESHOLD.moderate}-
+                                {ANOPHELES_THRESHOLD.high - 1}
+                            </span>
+                            <span className="flex items-center gap-1.5">
+                                <span
+                                    className="inline-block h-3 w-3 rounded-full"
+                                    style={{
+                                        backgroundColor:
+                                            ANOPHELES_COLOR.critical,
+                                    }}
+                                />
+                                {ANOPHELES_THRESHOLD.high}+
+                            </span>
+                        </div>
                     </div>
                 </div>
-            </div>
+            )}
         </Fragment>
     );
 }

--- a/src/features/operations/geographical-summary/components/specimens-view.tsx
+++ b/src/features/operations/geographical-summary/components/specimens-view.tsx
@@ -40,10 +40,6 @@ export default function SpecimensView({
         startDate,
         endDate,
     });
-    // const markers: SiteMarker[] = [];
-    // const totalSites = 0;
-    // const isPending = false;
-    // const isError = true;
 
     const siteMapMounted = useRef(false);
     if (!isPending && !isError && markers.length > 0)
@@ -56,11 +52,8 @@ export default function SpecimensView({
                     <p className="text-muted-foreground text-xs">
                         {t('uniqueSites')}
                     </p>
-                    {isPending || isError ? (
-                        <Skeleton
-                            className="h-5 w-8"
-                            variant={isError ? 'destructive' : 'default'}
-                        />
+                    {isPending ? (
+                        <Skeleton className="h-5 w-8" />
                     ) : (
                         <p className="text-lg leading-none font-bold">
                             {totalSites}

--- a/src/features/operations/geographical-summary/components/specimens-view.tsx
+++ b/src/features/operations/geographical-summary/components/specimens-view.tsx
@@ -40,9 +40,14 @@ export default function SpecimensView({
         startDate,
         endDate,
     });
+    // const markers: SiteMarker[] = [];
+    // const totalSites = 0;
+    // const isPending = false;
+    // const isError = true;
 
     const siteMapMounted = useRef(false);
-    if (!isPending && markers.length > 0) siteMapMounted.current = true;
+    if (!isPending && !isError && markers.length > 0)
+        siteMapMounted.current = true;
 
     return (
         <Fragment>
@@ -51,8 +56,11 @@ export default function SpecimensView({
                     <p className="text-muted-foreground text-xs">
                         {t('uniqueSites')}
                     </p>
-                    {isPending ? (
-                        <Skeleton className="h-5 w-8" />
+                    {isPending || isError ? (
+                        <Skeleton
+                            className="h-5 w-8"
+                            variant={isError ? 'destructive' : 'default'}
+                        />
                     ) : (
                         <p className="text-lg leading-none font-bold">
                             {totalSites}

--- a/src/features/operations/intervention-metrics/components/operations-intervention-metrics.tsx
+++ b/src/features/operations/intervention-metrics/components/operations-intervention-metrics.tsx
@@ -48,20 +48,7 @@ export default function OperationsInterventionMetrics({
         !isLoading &&
         failedSessionsMetricsQuery?.data &&
         !failedSessionsMetricsQuery.data.ok;
-    // if (
-    //     !isLoading &&
-    //     failedSessionsMetricsQuery?.data &&
-    //     !failedSessionsMetricsQuery.data.ok
-    // ) {
-    //     return (
-    //         <ErrorBanner
-    //             message={
-    //                 failedSessionsMetricsQuery.data.error.message ??
-    //                 t('failedToLoad')
-    //             }
-    //         />
-    //     );
-    // }
+
     const errorMessage =
         !isLoading &&
         failedSessionsMetricsQuery?.data &&

--- a/src/features/operations/intervention-metrics/components/operations-intervention-metrics.tsx
+++ b/src/features/operations/intervention-metrics/components/operations-intervention-metrics.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/features/operations/intervention-metrics/utils/intervention-metrics-helpers';
 import { useTranslations } from 'next-intl';
 import ErrorBanner from '@/components/ui/error-banner';
+import { cn } from '@/utils/cn';
 
 interface OperationsInterventionMetricsProps {
     sites: Site[];
@@ -43,20 +44,31 @@ export default function OperationsInterventionMetrics({
     const failedSessionsMetricsQuery = sessionsMetricsQueries.find(
         query => query.data && !query.data.ok,
     );
-    if (
+    const isError =
+        !isLoading &&
+        failedSessionsMetricsQuery?.data &&
+        !failedSessionsMetricsQuery.data.ok;
+    // if (
+    //     !isLoading &&
+    //     failedSessionsMetricsQuery?.data &&
+    //     !failedSessionsMetricsQuery.data.ok
+    // ) {
+    //     return (
+    //         <ErrorBanner
+    //             message={
+    //                 failedSessionsMetricsQuery.data.error.message ??
+    //                 t('failedToLoad')
+    //             }
+    //         />
+    //     );
+    // }
+    const errorMessage =
         !isLoading &&
         failedSessionsMetricsQuery?.data &&
         !failedSessionsMetricsQuery.data.ok
-    ) {
-        return (
-            <ErrorBanner
-                message={
-                    failedSessionsMetricsQuery.data.error.message ??
-                    t('failedToLoad')
-                }
-            />
-        );
-    }
+            ? (failedSessionsMetricsQuery.data.error.message ??
+              t('failedToLoad'))
+            : '';
 
     const interventionMetricsTotals = !isLoading
         ? buildInterventionMetricsTotals(
@@ -81,16 +93,35 @@ export default function OperationsInterventionMetrics({
                 </p>
             </div>
 
+            {isError && <ErrorBanner message={errorMessage} />}
+
             <div className="grid gap-3 sm:grid-cols-2">
-                <Card className={`${netUsageStatusStyle.card} gap-0 py-0`}>
+                <Card
+                    className={cn(
+                        !isError && `${netUsageStatusStyle.card}`,
+                        'gap-0 py-0',
+                    )}
+                >
                     <CardContent className="flex h-full flex-col p-4">
                         <p className="text-muted-foreground text-sm">
                             {t('netUsageTitle')}
                         </p>
-                        {isLoading ? (
+                        {isLoading || isError ? (
                             <div className="space-y-2 py-2">
-                                <Skeleton width="sm" height="xxl" />
-                                <Skeleton width="lg" height="sm" />
+                                <Skeleton
+                                    width="sm"
+                                    height="xxl"
+                                    variant={
+                                        isError ? 'destructive' : 'default'
+                                    }
+                                />
+                                <Skeleton
+                                    width="lg"
+                                    height="sm"
+                                    variant={
+                                        isError ? 'destructive' : 'default'
+                                    }
+                                />
                             </div>
                         ) : (
                             <Fragment>
@@ -145,10 +176,22 @@ export default function OperationsInterventionMetrics({
                         <p className="text-muted-foreground text-sm">
                             {t('peoplePerNetTitle')}
                         </p>
-                        {isLoading ? (
+                        {isLoading || isError ? (
                             <div className="space-y-2 py-2">
-                                <Skeleton width="sm" height="xxl" />
-                                <Skeleton width="lg" height="sm" />
+                                <Skeleton
+                                    width="sm"
+                                    height="xxl"
+                                    variant={
+                                        isError ? 'destructive' : 'default'
+                                    }
+                                />
+                                <Skeleton
+                                    width="lg"
+                                    height="sm"
+                                    variant={
+                                        isError ? 'destructive' : 'default'
+                                    }
+                                />
                             </div>
                         ) : (
                             <Fragment>

--- a/src/features/operations/intervention-metrics/components/operations-intervention-metrics.tsx
+++ b/src/features/operations/intervention-metrics/components/operations-intervention-metrics.tsx
@@ -15,6 +15,7 @@ import {
     getCoverageCardStyle,
 } from '@/features/operations/intervention-metrics/utils/intervention-metrics-helpers';
 import { useTranslations } from 'next-intl';
+import ErrorBanner from '@/components/ui/error-banner';
 
 interface OperationsInterventionMetricsProps {
     sites: Site[];
@@ -48,9 +49,12 @@ export default function OperationsInterventionMetrics({
         !failedSessionsMetricsQuery.data.ok
     ) {
         return (
-            <p className="text-destructive text-sm">
-                {failedSessionsMetricsQuery.data.error.message}
-            </p>
+            <ErrorBanner
+                message={
+                    failedSessionsMetricsQuery.data.error.message ??
+                    t('failedToLoad')
+                }
+            />
         );
     }
 

--- a/src/features/operations/intervention-metrics/components/operations-intervention-metrics.tsx
+++ b/src/features/operations/intervention-metrics/components/operations-intervention-metrics.tsx
@@ -5,7 +5,6 @@ import type { Site } from '@/api/site/validation/site-schema';
 import { useGetSessionsMetricsByDistricts } from '@/api/session/hooks/use-get-sessions-metrics';
 import { Card, CardContent } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
-import { Skeleton } from '@/components/ui/skeleton';
 import StatBadge from '@/components/ui/stat-badge';
 import { getUniqueDistricts } from '@/lib/location/site-tree';
 import {
@@ -17,6 +16,7 @@ import {
 import { useTranslations } from 'next-intl';
 import ErrorBanner from '@/components/ui/error-banner';
 import { cn } from '@/utils/cn';
+import { StatCardSkeleton } from '@/components/ui/stat-card-skeleton';
 
 interface OperationsInterventionMetricsProps {
     sites: Site[];
@@ -41,21 +41,10 @@ export default function OperationsInterventionMetrics({
 
     const isLoading = sessionsMetricsQueries.some(query => query.isPending);
 
-    const failedSessionsMetricsQuery = sessionsMetricsQueries.find(
+    const failedSessionsMetricsQuery = sessionsMetricsQueries.filter(
         query => query.data && !query.data.ok,
     );
-    const isError =
-        !isLoading &&
-        failedSessionsMetricsQuery?.data &&
-        !failedSessionsMetricsQuery.data.ok;
-
-    const errorMessage =
-        !isLoading &&
-        failedSessionsMetricsQuery?.data &&
-        !failedSessionsMetricsQuery.data.ok
-            ? (failedSessionsMetricsQuery.data.error.message ??
-              t('failedToLoad'))
-            : '';
+    const isError = !isLoading && failedSessionsMetricsQuery.length > 0;
 
     const interventionMetricsTotals = !isLoading
         ? buildInterventionMetricsTotals(
@@ -80,7 +69,7 @@ export default function OperationsInterventionMetrics({
                 </p>
             </div>
 
-            {isError && <ErrorBanner message={errorMessage} />}
+            {isError && <ErrorBanner message={t('failedToLoad')} />}
 
             <div className="grid gap-3 sm:grid-cols-2">
                 <Card
@@ -94,22 +83,9 @@ export default function OperationsInterventionMetrics({
                             {t('netUsageTitle')}
                         </p>
                         {isLoading || isError ? (
-                            <div className="space-y-2 py-2">
-                                <Skeleton
-                                    width="sm"
-                                    height="xxl"
-                                    variant={
-                                        isError ? 'destructive' : 'default'
-                                    }
-                                />
-                                <Skeleton
-                                    width="lg"
-                                    height="sm"
-                                    variant={
-                                        isError ? 'destructive' : 'default'
-                                    }
-                                />
-                            </div>
+                            <StatCardSkeleton
+                                variant={isError ? 'destructive' : 'default'}
+                            />
                         ) : (
                             <Fragment>
                                 <p className="mt-1 text-5xl font-semibold tracking-tight">
@@ -164,22 +140,9 @@ export default function OperationsInterventionMetrics({
                             {t('peoplePerNetTitle')}
                         </p>
                         {isLoading || isError ? (
-                            <div className="space-y-2 py-2">
-                                <Skeleton
-                                    width="sm"
-                                    height="xxl"
-                                    variant={
-                                        isError ? 'destructive' : 'default'
-                                    }
-                                />
-                                <Skeleton
-                                    width="lg"
-                                    height="sm"
-                                    variant={
-                                        isError ? 'destructive' : 'default'
-                                    }
-                                />
-                            </div>
+                            <StatCardSkeleton
+                                variant={isError ? 'destructive' : 'default'}
+                            />
                         ) : (
                             <Fragment>
                                 <p className="mt-1 text-5xl font-semibold tracking-tight">

--- a/src/features/operations/specimen-composition/components/composition-chart-pair.tsx
+++ b/src/features/operations/specimen-composition/components/composition-chart-pair.tsx
@@ -37,6 +37,7 @@ interface CompositionChartPairProps {
     specimenCountsByMonth: Record<string, string | number>[];
     specimenChartConfig: ChartConfig;
     isLoading: boolean;
+    isError: boolean;
 }
 
 export default function CompositionChartPair({
@@ -46,6 +47,7 @@ export default function CompositionChartPair({
     specimenCountsByMonth,
     specimenChartConfig,
     isLoading,
+    isError,
 }: CompositionChartPairProps) {
     const t = useTranslations('OperationsSpecimenComposition');
     const specimenClasses = Object.keys(specimenChartConfig);
@@ -113,8 +115,13 @@ export default function CompositionChartPair({
                 ) : (
                     <div className="flex flex-col items-center gap-6 lg:flex-row">
                         <div className="h-62.5 w-62.5 shrink-0">
-                            {isLoading ? (
-                                <Skeleton className="h-full w-full rounded-full" />
+                            {isLoading || isError ? (
+                                <Skeleton
+                                    className="h-full w-full rounded-full"
+                                    variant={
+                                        isError ? 'destructive' : 'default'
+                                    }
+                                />
                             ) : (
                                 <ChartContainer
                                     config={specimenChartConfig}
@@ -198,8 +205,13 @@ export default function CompositionChartPair({
                             )}
                         </div>
                         <div className="h-72 w-full min-w-0 flex-1">
-                            {isLoading ? (
-                                <Skeleton className="h-64 w-full" />
+                            {isLoading || isError ? (
+                                <Skeleton
+                                    className="h-64 w-full"
+                                    variant={
+                                        isError ? 'destructive' : 'default'
+                                    }
+                                />
                             ) : (
                                 <ChartContainer
                                     config={specimenChartConfig}

--- a/src/features/operations/specimen-composition/components/composition-chart-pair.tsx
+++ b/src/features/operations/specimen-composition/components/composition-chart-pair.tsx
@@ -24,6 +24,7 @@ import {
 import { Fragment } from 'react/jsx-runtime';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useTranslations } from 'next-intl';
+import EmptyBanner from '@/components/ui/empty-banner';
 
 type ChartType = 'bar' | 'line';
 
@@ -109,9 +110,7 @@ export default function CompositionChartPair({
             </CardHeader>
             <CardContent>
                 {!isLoading && !isError && totalSpecimenCount === 0 ? (
-                    <div className="text-muted-foreground flex items-center justify-center py-12 text-sm">
-                        {t('noSpecimenData')}
-                    </div>
+                    <EmptyBanner message={t('noSpecimenData')} />
                 ) : (
                     <div className="flex flex-col items-center gap-6 lg:flex-row">
                         <div className="h-62.5 w-62.5 shrink-0">

--- a/src/features/operations/specimen-composition/components/composition-chart-pair.tsx
+++ b/src/features/operations/specimen-composition/components/composition-chart-pair.tsx
@@ -108,7 +108,7 @@ export default function CompositionChartPair({
                 <CardTitle className="text-base">{title}</CardTitle>
             </CardHeader>
             <CardContent>
-                {!isLoading && totalSpecimenCount === 0 ? (
+                {!isLoading && !isError && totalSpecimenCount === 0 ? (
                     <div className="text-muted-foreground flex items-center justify-center py-12 text-sm">
                         {t('noSpecimenData')}
                     </div>

--- a/src/features/operations/specimen-composition/components/operations-specimen-composition.tsx
+++ b/src/features/operations/specimen-composition/components/operations-specimen-composition.tsx
@@ -152,7 +152,7 @@ export default function OperationsSpecimenComposition({
                     </ToggleGroup>
                 </div>
             </div>
-            {isLoading ? (
+            {isLoading || isError ? (
                 COMPOSITION_SECTIONS.map(
                     ({ specimenClassificationAxis, title }) => (
                         <CompositionChartPair

--- a/src/features/operations/specimen-composition/components/operations-specimen-composition.tsx
+++ b/src/features/operations/specimen-composition/components/operations-specimen-composition.tsx
@@ -167,7 +167,7 @@ export default function OperationsSpecimenComposition({
                         />
                     ),
                 )
-            ) : validSelectedSpecies.length === 0 ? (
+            ) : !isError && validSelectedSpecies.length === 0 ? (
                 <EmptyBanner message={t('monthlySpecimenCountsEmpty')} />
             ) : (
                 monthlySpecimenCounts &&

--- a/src/features/operations/specimen-composition/components/operations-specimen-composition.tsx
+++ b/src/features/operations/specimen-composition/components/operations-specimen-composition.tsx
@@ -167,7 +167,7 @@ export default function OperationsSpecimenComposition({
                         />
                     ),
                 )
-            ) : !isError && validSelectedSpecies.length === 0 ? (
+            ) : validSelectedSpecies.length === 0 ? (
                 <EmptyBanner message={t('monthlySpecimenCountsEmpty')} />
             ) : (
                 monthlySpecimenCounts &&

--- a/src/features/operations/specimen-composition/components/operations-specimen-composition.tsx
+++ b/src/features/operations/specimen-composition/components/operations-specimen-composition.tsx
@@ -26,6 +26,7 @@ import { useTranslations } from 'next-intl';
 import EmptyBanner from '@/components/ui/empty-banner';
 import { BarChart3, LineChart } from 'lucide-react';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import ErrorBanner from '@/components/ui/error-banner';
 
 const COMPOSITION_SECTIONS: {
     specimenClassificationAxis: SpecimenClassificationAxis;
@@ -81,15 +82,7 @@ export default function OperationsSpecimenComposition({
 
     const isLoading =
         isGetMonthlySpecimensCountPending || !getMonthlySpecimensCountResult;
-
-    if (!isLoading && !getMonthlySpecimensCountResult.ok) {
-        return (
-            <h1>
-                {t('monthlySpecimenCountsError')}
-                {getMonthlySpecimensCountResult.error.message}
-            </h1>
-        );
-    }
+    const isError = !isLoading && !getMonthlySpecimensCountResult.ok;
 
     const monthlySpecimenCounts = getMonthlySpecimensCountResult?.ok
         ? getMonthlySpecimensCountResult.data.data
@@ -97,6 +90,9 @@ export default function OperationsSpecimenComposition({
 
     return (
         <div className="space-y-6">
+            {isError && (
+                <ErrorBanner message={t('monthlySpecimenCountsError')} />
+            )}
             <div className="flex flex-col gap-1.5">
                 <Label className="text-sm font-medium">
                     {t('filterBySpecies')}
@@ -109,7 +105,7 @@ export default function OperationsSpecimenComposition({
                         }
                     >
                         <MultiSelectTrigger
-                            disabled={isLoading}
+                            disabled={isLoading || isError}
                             className="min-w-0 flex-1"
                         >
                             <MultiSelectValue
@@ -142,7 +138,7 @@ export default function OperationsSpecimenComposition({
                         onValueChange={(next: ChartType | '') => {
                             if (next) setChartType(next);
                         }}
-                        disabled={isLoading}
+                        disabled={isLoading || isError}
                         className="shrink-0"
                     >
                         <ToggleGroupItem value="bar">
@@ -167,6 +163,7 @@ export default function OperationsSpecimenComposition({
                             specimenCountsByMonth={[]}
                             specimenChartConfig={{}}
                             isLoading={isLoading}
+                            isError={isError}
                         />
                     ),
                 )
@@ -203,6 +200,7 @@ export default function OperationsSpecimenComposition({
                                 specimenCountsByMonth={specimenCountsByMonth}
                                 specimenChartConfig={specimenChartConfig}
                                 isLoading={isLoading}
+                                isError={isError}
                             />
                         );
                     },


### PR DESCRIPTION
* Geographical summary: added error banner appearance for if there's an error getting the country; adjusted device-view formatting to match structure for specimen-view
* Specimen composition: add error banner, disable filter + bar/line graph toggle, make loading skeletons destructive on error 
* AI performance: make loading skeletons destructive on error; replace the 'coverage reflects' banner at the top with the error banner
* Field user compliance: add error banner, make loading skeleton destructive

Currently debating whether to match error states closer to geographical summary or to match geographical summary's error states to the other ones