### PR TITLE
VCV-253: enforce required metadata fields, contrain select fields to a closed dropdown

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -184,8 +184,10 @@
     "ReviewMetadata": {
         "intro": "Review the metadata for this unit before continuing.",
         "legendConflict": "Conflicting values must be resolved to continue",
+        "legendRequired": "Required answers must be supplied to continue",
         "legendEdit": "Edit any value to correct it (optional)",
         "conflictsRemaining": "{count, plural, one {# conflict left to resolve} other {# conflicts left to resolve}}",
+        "requiredAnswersRemaining": "{count, plural, one {# required answer left to supply} other {# required answers left to supply}}",
         "editValueLabel": "Edit value",
         "valueColumn": "Value",
         "collectionDate": "Collection Date: ",

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -69,7 +69,14 @@ export function ComboBox({
                     )}
                     disabled={disabled}
                 >
-                    <span className="truncate">{value ?? placeholder}</span>
+                    <span
+                        className={cn(
+                            'truncate',
+                            !value && 'text-muted-foreground',
+                        )}
+                    >
+                        {value ?? placeholder}
+                    </span>
                     <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                 </Button>
             </PopoverTrigger>

--- a/src/features/review/workspace/metadata/components/conflict-resolution-control.tsx
+++ b/src/features/review/workspace/metadata/components/conflict-resolution-control.tsx
@@ -19,6 +19,7 @@ import {
 interface ConflictResolutionControlProps {
     fieldType: FormQuestionType;
     options: string[];
+    questionOptions: string[] | null;
     value: string | undefined;
     onValueChange: (value: string) => void;
     disabled: boolean;
@@ -27,6 +28,7 @@ interface ConflictResolutionControlProps {
 export default function ConflictResolutionControl({
     fieldType,
     options,
+    questionOptions,
     value,
     onValueChange,
     disabled,
@@ -38,17 +40,15 @@ export default function ConflictResolutionControl({
         return /^\d+$/.test(input) ? null : t('wholeNonNegativeIntegerError');
     }
 
-    if (fieldType === 'boolean') {
-        const booleanOptions = [
-            ...new Set([
-                BOOLEAN_TRUE_DISPLAY,
-                BOOLEAN_FALSE_DISPLAY,
-                ...options,
-            ]),
-        ];
+    if (fieldType === 'boolean' || fieldType === 'select') {
+        const selectOptions =
+            fieldType === 'boolean'
+                ? [BOOLEAN_TRUE_DISPLAY, BOOLEAN_FALSE_DISPLAY]
+                : (questionOptions ?? []);
+        const selectValue = value === NOT_APPLICABLE ? undefined : value;
         return (
             <Select
-                value={value}
+                value={selectValue}
                 onValueChange={onValueChange}
                 disabled={disabled}
             >
@@ -56,7 +56,7 @@ export default function ConflictResolutionControl({
                     <SelectValue placeholder={t('selectValuePlaceholder')} />
                 </SelectTrigger>
                 <SelectContent>
-                    {booleanOptions.map(option => (
+                    {selectOptions.map(option => (
                         <SelectItem key={option} value={option}>
                             {option}
                         </SelectItem>

--- a/src/features/review/workspace/metadata/components/conflict-resolution-control.tsx
+++ b/src/features/review/workspace/metadata/components/conflict-resolution-control.tsx
@@ -45,7 +45,8 @@ export default function ConflictResolutionControl({
             fieldType === 'boolean'
                 ? [BOOLEAN_TRUE_DISPLAY, BOOLEAN_FALSE_DISPLAY]
                 : (questionOptions ?? []);
-        const selectValue = value === NOT_APPLICABLE ? undefined : value;
+        const selectValue =
+            value === NOT_APPLICABLE || value === undefined ? '' : value;
         return (
             <Select
                 value={selectValue}

--- a/src/features/review/workspace/metadata/components/metadata-review-table.tsx
+++ b/src/features/review/workspace/metadata/components/metadata-review-table.tsx
@@ -124,7 +124,11 @@ export default function MetadataReviewTable({
                             const resolutionOptions = [
                                 ...new Set(
                                     [...row.fieldValueBySessionId.values()].map(
-                                        formatDisplayValue,
+                                        value =>
+                                            formatDisplayValue(
+                                                value,
+                                                row.fieldType,
+                                            ),
                                     ),
                                 ),
                             ];
@@ -204,6 +208,7 @@ export default function MetadataReviewTable({
                                                 row.fieldValueBySessionId.get(
                                                     session.sessionId,
                                                 ),
+                                                row.fieldType,
                                             );
                                         const effectiveDisplayValue =
                                             isRowDisabled

--- a/src/features/review/workspace/metadata/components/metadata-review-table.tsx
+++ b/src/features/review/workspace/metadata/components/metadata-review-table.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { Session } from '@/api/session/validation/session-schema';
+import { Button } from '@/components/ui/button';
 import {
     Table,
     TableBody,
@@ -11,7 +12,7 @@ import {
 } from '@/components/ui/table';
 import { cn } from '@/utils/cn';
 import { formatDateInTimezone } from '@/utils/format-date-in-timezone';
-import { CircleCheck, Pencil, TriangleAlert } from 'lucide-react';
+import { CircleAlert, CircleCheck, Pencil, TriangleAlert } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Fragment, useState } from 'react';
 import {
@@ -20,7 +21,6 @@ import {
     type MetadataSection,
 } from '../utils/metadata-section';
 import ConflictResolutionControl from './conflict-resolution-control';
-import { Button } from '@/components/ui/button';
 
 interface MetadataReviewTableProps {
     sessions: Session[];
@@ -32,6 +32,7 @@ interface MetadataReviewTableProps {
         chosenDisplayValue: string,
     ) => void;
     disabledRowIds: Set<string>;
+    unmetRequiredRowIds: Set<string>;
     readOnly: boolean;
 }
 
@@ -42,6 +43,7 @@ export default function MetadataReviewTable({
     resolutionsByMetadataRowId,
     onConflictResolutionChange,
     disabledRowIds,
+    unmetRequiredRowIds,
     readOnly,
 }: MetadataReviewTableProps) {
     const t = useTranslations('ReviewMetadata');
@@ -56,204 +58,220 @@ export default function MetadataReviewTable({
     }
 
     return (
-        <div className="overflow-x-auto">
-            <Table className="border-border rounded-md border">
-                <TableHeader>
-                    <TableRow className="h-14">
-                        <TableHead className="border-border w-48 border" />
-                        {sessions.map(session => (
-                            <TableHead
-                                key={session.sessionId}
-                                className="border-border border p-2"
-                            >
-                                <div>
-                                    {t('collectionDate')}
+        <Table
+            className="border-border rounded-md border"
+            containerClassName="max-h-[calc(100vh-24rem)] overflow-y-auto"
+        >
+            <TableHeader className="bg-background sticky top-0 z-30">
+                <TableRow className="h-14">
+                    <TableHead className="border-border w-48 border" />
+                    {sessions.map(session => (
+                        <TableHead
+                            key={session.sessionId}
+                            className="border-border border p-2"
+                        >
+                            <div>
+                                {t('collectionDate')}
+                                {formatDateInTimezone(
+                                    session.collectionDate,
+                                    timezone,
+                                    'MMM d, yyyy',
+                                )}
+                            </div>
+                            <div>
+                                {t('sessionCreated')}
+                                <span className="block pl-4">
                                     {formatDateInTimezone(
-                                        session.collectionDate,
+                                        session.createdAt,
                                         timezone,
-                                        'MMM d, yyyy',
+                                        'MMM d, yyyy h:mm a',
                                     )}
-                                </div>
-                                <div>
-                                    {t('sessionCreated')}
-                                    <span className="block pl-4">
-                                        {formatDateInTimezone(
-                                            session.createdAt,
-                                            timezone,
-                                            'MMM d, yyyy h:mm a',
-                                        )}
-                                    </span>
-                                </div>
-                            </TableHead>
-                        ))}
-                        {!readOnly && (
-                            <TableHead className="border-border bg-background sticky right-0 z-20 w-72 border font-semibold">
-                                {t('valueColumn')}
-                            </TableHead>
+                                </span>
+                            </div>
+                        </TableHead>
+                    ))}
+                    {!readOnly && (
+                        <TableHead className="border-border bg-background sticky right-0 z-40 w-72 border font-semibold">
+                            {t('valueColumn')}
+                        </TableHead>
+                    )}
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {sections.map(section => (
+                    <Fragment key={section.key}>
+                        {showSectionHeaders && (
+                            <TableRow className="bg-muted/50 h-12">
+                                <TableCell
+                                    colSpan={sectionHeaderColSpan}
+                                    className="border-border border font-semibold"
+                                >
+                                    {section.title ?? t('sessionSectionTitle')}
+                                </TableCell>
+                            </TableRow>
                         )}
-                    </TableRow>
-                </TableHeader>
-                <TableBody>
-                    {sections.map(section => (
-                        <Fragment key={section.key}>
-                            {showSectionHeaders && (
-                                <TableRow className="bg-muted/50 h-12">
-                                    <TableCell
-                                        colSpan={sectionHeaderColSpan}
-                                        className="border-border border font-semibold"
-                                    >
-                                        {section.title ??
-                                            t('sessionSectionTitle')}
-                                    </TableCell>
-                                </TableRow>
-                            )}
-                            {section.rows.map(row => {
-                                const isRowDisabled = disabledRowIds.has(
-                                    row.id,
-                                );
-                                const isResolved =
-                                    resolutionsByMetadataRowId.has(row.id) ||
-                                    isRowDisabled;
-                                const chosenResolution = isRowDisabled
-                                    ? NOT_APPLICABLE
-                                    : resolutionsByMetadataRowId.get(row.id);
-                                const resolutionOptions = [
-                                    ...new Set(
-                                        [
-                                            ...row.fieldValueBySessionId.values(),
-                                        ].map(formatDisplayValue),
+                        {section.rows.map(row => {
+                            const isRowDisabled = disabledRowIds.has(row.id);
+                            const isUnmetRowRequired = unmetRequiredRowIds.has(
+                                row.id,
+                            );
+                            const isResolved =
+                                resolutionsByMetadataRowId.has(row.id) ||
+                                isRowDisabled;
+                            const chosenResolution = isRowDisabled
+                                ? NOT_APPLICABLE
+                                : resolutionsByMetadataRowId.get(row.id);
+                            const resolutionOptions = [
+                                ...new Set(
+                                    [...row.fieldValueBySessionId.values()].map(
+                                        formatDisplayValue,
                                     ),
-                                ];
-                                const isUnitRow = section.title !== null;
+                                ),
+                            ];
+                            const isUnitRow = section.title !== null;
 
-                                const controlValue =
-                                    chosenResolution ??
-                                    (row.hasConflict
-                                        ? undefined
-                                        : resolutionOptions[0]);
-                                const showControl =
-                                    row.hasConflict ||
-                                    editingRowIds.has(row.id) ||
-                                    resolutionsByMetadataRowId.has(row.id);
+                            const fallbackValue = row.hasConflict
+                                ? undefined
+                                : resolutionOptions[0];
+                            const controlValue =
+                                chosenResolution ??
+                                (fallbackValue === NOT_APPLICABLE
+                                    ? undefined
+                                    : fallbackValue);
+                            const showControl =
+                                row.hasConflict ||
+                                isUnmetRowRequired ||
+                                editingRowIds.has(row.id) ||
+                                resolutionsByMetadataRowId.has(row.id);
 
-                                return (
-                                    <TableRow
-                                        key={row.id}
+                            let RowIcon: typeof CircleAlert | null = null;
+                            if (!readOnly) {
+                                if (isUnmetRowRequired) {
+                                    RowIcon = CircleAlert;
+                                } else if (row.hasConflict) {
+                                    RowIcon = isResolved
+                                        ? CircleCheck
+                                        : TriangleAlert;
+                                }
+                            }
+
+                            return (
+                                <TableRow
+                                    key={row.id}
+                                    className={cn(
+                                        'h-14',
+                                        !readOnly &&
+                                            ((row.hasConflict && !isResolved) ||
+                                                isUnmetRowRequired) &&
+                                            'bg-destructive/10 hover:bg-destructive/15',
+                                    )}
+                                >
+                                    <TableCell
                                         className={cn(
-                                            'h-14',
-                                            row.hasConflict &&
-                                                !isResolved &&
-                                                !readOnly &&
-                                                'bg-destructive/10 hover:bg-destructive/15',
+                                            'border-border w-48 border font-medium',
+                                            isUnitRow && 'pl-8',
                                         )}
                                     >
-                                        <TableCell
-                                            className={cn(
-                                                'border-border w-48 border font-medium',
-                                                isUnitRow && 'pl-8',
+                                        <div className="flex items-center gap-2">
+                                            {RowIcon && (
+                                                <RowIcon
+                                                    className={cn(
+                                                        'h-4 w-4 shrink-0',
+                                                        RowIcon === CircleCheck
+                                                            ? 'text-green-600'
+                                                            : 'text-destructive',
+                                                    )}
+                                                />
                                             )}
-                                        >
-                                            <div className="flex items-center gap-2">
-                                                {row.hasConflict &&
-                                                    !readOnly &&
-                                                    (isResolved ? (
-                                                        <CircleCheck className="h-4 w-4 shrink-0 text-green-600" />
-                                                    ) : (
-                                                        <TriangleAlert className="text-destructive h-4 w-4 shrink-0" />
-                                                    ))}
-                                                {row.label}
-                                            </div>
-                                        </TableCell>
-                                        {sessions.map(session => {
-                                            if (
-                                                !row.fieldValueBySessionId.has(
-                                                    session.sessionId,
-                                                )
-                                            ) {
-                                                return (
-                                                    <TableCell
-                                                        key={session.sessionId}
-                                                        className="border-border border"
-                                                    />
-                                                );
-                                            }
-                                            const originalDisplayValue =
-                                                formatDisplayValue(
-                                                    row.fieldValueBySessionId.get(
-                                                        session.sessionId,
-                                                    ),
-                                                );
-                                            const effectiveDisplayValue =
-                                                isRowDisabled
-                                                    ? NOT_APPLICABLE
-                                                    : (chosenResolution ??
-                                                      originalDisplayValue);
+                                            {row.label}
+                                        </div>
+                                    </TableCell>
+                                    {sessions.map(session => {
+                                        if (
+                                            !row.fieldValueBySessionId.has(
+                                                session.sessionId,
+                                            )
+                                        ) {
                                             return (
                                                 <TableCell
                                                     key={session.sessionId}
-                                                    className={cn(
-                                                        'border-border border',
-                                                        effectiveDisplayValue !==
-                                                            originalDisplayValue &&
-                                                            'bg-primary/10',
-                                                    )}
-                                                >
-                                                    {effectiveDisplayValue}
-                                                </TableCell>
+                                                    className="border-border border"
+                                                />
                                             );
-                                        })}
-                                        {!readOnly && (
-                                            <TableCell className="border-border bg-background sticky right-0 z-20 w-72 border">
-                                                {isRowDisabled ? (
-                                                    <span className="text-muted-foreground pl-3 text-sm">
-                                                        {NOT_APPLICABLE}
-                                                    </span>
-                                                ) : showControl ? (
-                                                    <ConflictResolutionControl
-                                                        fieldType={
-                                                            row.fieldType
-                                                        }
-                                                        options={
-                                                            resolutionOptions
-                                                        }
-                                                        value={controlValue}
-                                                        onValueChange={value =>
-                                                            onConflictResolutionChange(
-                                                                row.id,
-                                                                value,
-                                                            )
-                                                        }
-                                                        disabled={false}
-                                                    />
-                                                ) : (
-                                                    <Button
-                                                        variant="ghost"
-                                                        onClick={() =>
-                                                            startEditingRow(
-                                                                row.id,
-                                                            )
-                                                        }
-                                                        aria-label={t(
-                                                            'editValueLabel',
-                                                        )}
-                                                        className="h-auto w-72 justify-between px-3 py-1.5 font-normal"
-                                                    >
-                                                        <span className="truncate">
-                                                            {controlValue ??
-                                                                NOT_APPLICABLE}
-                                                        </span>
-                                                        <Pencil className="text-muted-foreground ml-2 h-3.5 w-3.5 shrink-0" />
-                                                    </Button>
+                                        }
+                                        const originalDisplayValue =
+                                            formatDisplayValue(
+                                                row.fieldValueBySessionId.get(
+                                                    session.sessionId,
+                                                ),
+                                            );
+                                        const effectiveDisplayValue =
+                                            isRowDisabled
+                                                ? NOT_APPLICABLE
+                                                : (chosenResolution ??
+                                                  originalDisplayValue);
+                                        return (
+                                            <TableCell
+                                                key={session.sessionId}
+                                                className={cn(
+                                                    'border-border border',
+                                                    effectiveDisplayValue !==
+                                                        originalDisplayValue &&
+                                                        'bg-primary/10',
                                                 )}
+                                            >
+                                                {effectiveDisplayValue}
                                             </TableCell>
-                                        )}
-                                    </TableRow>
-                                );
-                            })}
-                        </Fragment>
-                    ))}
-                </TableBody>
-            </Table>
-        </div>
+                                        );
+                                    })}
+                                    {!readOnly && (
+                                        <TableCell className="border-border bg-background sticky right-0 z-20 w-72 border">
+                                            {isRowDisabled ? (
+                                                <span className="text-muted-foreground pl-3 text-sm">
+                                                    {NOT_APPLICABLE}
+                                                </span>
+                                            ) : showControl ? (
+                                                <ConflictResolutionControl
+                                                    fieldType={row.fieldType}
+                                                    options={resolutionOptions}
+                                                    questionOptions={
+                                                        row.options
+                                                    }
+                                                    value={controlValue}
+                                                    onValueChange={value =>
+                                                        onConflictResolutionChange(
+                                                            row.id,
+                                                            value,
+                                                        )
+                                                    }
+                                                    disabled={false}
+                                                />
+                                            ) : (
+                                                <Button
+                                                    variant="ghost"
+                                                    onClick={() =>
+                                                        startEditingRow(row.id)
+                                                    }
+                                                    aria-label={t(
+                                                        'editValueLabel',
+                                                    )}
+                                                    className="h-auto w-72 justify-between px-3 py-1.5 font-normal"
+                                                >
+                                                    <span className="truncate">
+                                                        {controlValue ??
+                                                            NOT_APPLICABLE}
+                                                    </span>
+                                                    <Pencil className="text-muted-foreground ml-2 h-3.5 w-3.5 shrink-0" />
+                                                </Button>
+                                            )}
+                                        </TableCell>
+                                    )}
+                                </TableRow>
+                            );
+                        })}
+                    </Fragment>
+                ))}
+            </TableBody>
+        </Table>
     );
 }

--- a/src/features/review/workspace/metadata/components/metadata-review-workspace.tsx
+++ b/src/features/review/workspace/metadata/components/metadata-review-workspace.tsx
@@ -4,6 +4,7 @@ import { formAnswerKeys } from '@/api/form-answer/form-answer-keys';
 import { useGetFormAnswersBySessionIds } from '@/api/form-answer/hooks/use-get-form-answers-by-session-id';
 import type { FormAnswer } from '@/api/form-answer/validation/form-answer-schema';
 import { useGetCurrentFormByProgramId } from '@/api/form/hooks/use-get-current-form-by-program-id';
+import type { FormQuestion } from '@/api/form-question/validation/form-question-schema';
 import { useResolveSessionConflicts } from '@/api/session/hooks/use-resolve-session-conflicts';
 import { sessionKeys } from '@/api/session/session-keys';
 import type { Session } from '@/api/session/validation/session-schema';
@@ -15,7 +16,7 @@ import { Button } from '@/components/ui/button';
 import { SkeletonList } from '@/components/ui/skeleton-list';
 import { formatDateInTimezone } from '@/utils/format-date-in-timezone';
 import { useQueryClient } from '@tanstack/react-query';
-import { Pencil, TriangleAlert } from 'lucide-react';
+import { CircleAlert, Pencil, TriangleAlert } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { toast } from 'sonner';
@@ -28,8 +29,10 @@ import {
     flattenQuestions,
     type MetadataSection,
 } from '../utils/metadata-section';
-import { evaluateDisabledRowIds } from '../utils/evaluate-question-answerability';
-import type { FormQuestion } from '@/api/form-question/validation/form-question-schema';
+import {
+    evaluateDisabledRowIds,
+    evaluateUnmetRequiredRowIds,
+} from '../utils/evaluate-question-answerability';
 import MetadataReviewTable from './metadata-review-table';
 
 interface MetadataReviewWorkspaceProps {
@@ -231,12 +234,19 @@ export default function MetadataReviewWorkspace({
         questionsById,
     );
 
+    const unmetRequiredRowIds = evaluateUnmetRequiredRowIds(
+        sections,
+        resolutionsByMetadataRowId,
+        disabledRowIds,
+    );
+
     const areAllConflictsResolved = sections.every(section =>
         section.rows.every(
             row =>
-                !row.hasConflict ||
-                resolutionsByMetadataRowId.has(row.id) ||
-                disabledRowIds.has(row.id),
+                (!row.hasConflict ||
+                    resolutionsByMetadataRowId.has(row.id) ||
+                    disabledRowIds.has(row.id)) &&
+                !unmetRequiredRowIds.has(row.id),
         ),
     );
 
@@ -251,6 +261,8 @@ export default function MetadataReviewWorkspace({
             ).length,
         0,
     );
+
+    const unmetRequiredCount = unmetRequiredRowIds.size;
 
     async function resolveConflictsAndContinue() {
         const resolvableSessionIds = resolvableSessions.map(
@@ -338,6 +350,12 @@ export default function MetadataReviewWorkspace({
                                 {t('legendConflict')}
                             </span>
                         )}
+                        {unmetRequiredCount > 0 && (
+                            <span className="text-destructive flex items-center gap-1.5">
+                                <CircleAlert className="h-3.5 w-3.5 shrink-0" />
+                                {t('legendRequired')}
+                            </span>
+                        )}
                     </div>
                 </div>
             )}
@@ -371,6 +389,7 @@ export default function MetadataReviewWorkspace({
                 resolutionsByMetadataRowId={resolutionsByMetadataRowId}
                 onConflictResolutionChange={handleConflictResolutionChange}
                 disabledRowIds={disabledRowIds}
+                unmetRequiredRowIds={unmetRequiredRowIds}
                 readOnly={readOnly}
             />
 
@@ -380,6 +399,14 @@ export default function MetadataReviewWorkspace({
                         <TriangleAlert className="h-4 w-4 shrink-0" />
                         {t('conflictsRemaining', {
                             count: unresolvedConflictCount,
+                        })}
+                    </p>
+                )}
+                {!readOnly && unmetRequiredCount > 0 && (
+                    <p className="text-destructive flex items-center gap-1.5 text-sm">
+                        <CircleAlert className="h-4 w-4 shrink-0" />
+                        {t('requiredAnswersRemaining', {
+                            count: unmetRequiredCount,
                         })}
                     </p>
                 )}

--- a/src/features/review/workspace/metadata/utils/evaluate-question-answerability.ts
+++ b/src/features/review/workspace/metadata/utils/evaluate-question-answerability.ts
@@ -88,7 +88,9 @@ function resolveRowEffectiveValue(
     }
 
     const distinctValues = new Set(
-        [...row.fieldValueBySessionId.values()].map(formatDisplayValue),
+        [...row.fieldValueBySessionId.values()].map(value =>
+            formatDisplayValue(value, row.fieldType),
+        ),
     );
     if (distinctValues.size !== 1) return undefined;
     const [onlyValue] = distinctValues;

--- a/src/features/review/workspace/metadata/utils/evaluate-question-answerability.ts
+++ b/src/features/review/workspace/metadata/utils/evaluate-question-answerability.ts
@@ -1,24 +1,12 @@
 import type { FormQuestion } from '@/api/form-question/validation/form-question-schema';
 import { isPrerequisiteMet } from './evaluate-prerequisite';
-import { NOT_APPLICABLE, type MetadataSection } from './metadata-section';
-
-const SURVEILLANCE_FIELD_DEPENDENCIES: Record<
-    string,
-    { dependentRowIds: string[]; disablingDisplayValues: string[] }
-> = {
-    'surveillanceForm.wasIrsConducted': {
-        dependentRowIds: ['surveillanceForm.monthsSinceIrs'],
-        disablingDisplayValues: ['No', NOT_APPLICABLE],
-    },
-    'surveillanceForm.numLlinsAvailable': {
-        dependentRowIds: [
-            'surveillanceForm.llinType',
-            'surveillanceForm.llinBrand',
-            'surveillanceForm.numPeopleSleptUnderLlin',
-        ],
-        disablingDisplayValues: ['0', NOT_APPLICABLE],
-    },
-};
+import {
+    NOT_APPLICABLE,
+    SURVEILLANCE_FIELD_DEPENDENCIES,
+    formatDisplayValue,
+    type MetadataRow,
+    type MetadataSection,
+} from './metadata-section';
 
 export function evaluateDisabledRowIds(
     sections: MetadataSection[],
@@ -26,13 +14,22 @@ export function evaluateDisabledRowIds(
     questionsById: Map<number, FormQuestion>,
 ): Set<string> {
     const disabledRowIds = new Set<string>();
+    const allRows = sections.flatMap(section => section.rows);
 
     for (const [parentRowId, dependency] of Object.entries(
         SURVEILLANCE_FIELD_DEPENDENCIES,
     )) {
-        const parentResolution =
-            resolutionsByMetadataRowId.get(parentRowId) ?? '';
-        if (dependency.disablingDisplayValues.includes(parentResolution)) {
+        const parentRow = allRows.find(row => row.id === parentRowId);
+        const parentValue = parentRow
+            ? resolveRowEffectiveValue(
+                  parentRow,
+                  resolutionsByMetadataRowId,
+                  disabledRowIds,
+              )
+            : null;
+        if (parentValue === undefined) continue;
+        const parentDisplayValue = parentValue ?? NOT_APPLICABLE;
+        if (dependency.disablingDisplayValues.includes(parentDisplayValue)) {
             for (const dependentRowId of dependency.dependentRowIds) {
                 disabledRowIds.add(dependentRowId);
             }
@@ -51,15 +48,23 @@ export function evaluateDisabledRowIds(
                     Number(row.fieldName),
                 )?.prerequisite;
                 if (!prerequisite) continue;
-                const met = isPrerequisiteMet(prerequisite, questionId =>
-                    resolveEffectiveValue(
-                        questionId,
-                        section,
-                        resolutionsByMetadataRowId,
-                        disabledRowIds,
-                    ),
+                const prerequisiteMet = isPrerequisiteMet(
+                    prerequisite,
+                    questionId => {
+                        const dependencyRow = section.rows.find(
+                            candidate =>
+                                Number(candidate.fieldName) === questionId,
+                        );
+                        return dependencyRow
+                            ? resolveRowEffectiveValue(
+                                  dependencyRow,
+                                  resolutionsByMetadataRowId,
+                                  disabledRowIds,
+                              )
+                            : undefined;
+                    },
                 );
-                if (!met) {
+                if (!prerequisiteMet) {
                     disabledRowIds.add(row.id);
                     disabledAnyRow = true;
                 }
@@ -70,16 +75,11 @@ export function evaluateDisabledRowIds(
     return disabledRowIds;
 }
 
-function resolveEffectiveValue(
-    questionId: number,
-    section: MetadataSection,
+function resolveRowEffectiveValue(
+    row: MetadataRow,
     resolutionsByMetadataRowId: Map<string, string>,
     disabledRowIds: Set<string>,
 ): string | null | undefined {
-    const row = section.rows.find(
-        candidate => Number(candidate.fieldName) === questionId,
-    );
-    if (!row) return undefined;
     if (disabledRowIds.has(row.id)) return null;
 
     const resolution = resolutionsByMetadataRowId.get(row.id);
@@ -88,11 +88,34 @@ function resolveEffectiveValue(
     }
 
     const distinctValues = new Set(
-        [...row.fieldValueBySessionId.values()].map(value =>
-            value == null ? null : String(value),
-        ),
+        [...row.fieldValueBySessionId.values()].map(formatDisplayValue),
     );
     if (distinctValues.size !== 1) return undefined;
     const [onlyValue] = distinctValues;
-    return onlyValue ?? null;
+    return onlyValue === NOT_APPLICABLE ? null : onlyValue;
+}
+
+export function evaluateUnmetRequiredRowIds(
+    sections: MetadataSection[],
+    resolutionsByMetadataRowId: Map<string, string>,
+    disabledRowIds: Set<string>,
+): Set<string> {
+    const unmetRequiredRowIds = new Set<string>();
+
+    for (const section of sections) {
+        for (const row of section.rows) {
+            if (!row.required || disabledRowIds.has(row.id)) continue;
+
+            const effectiveValue = resolveRowEffectiveValue(
+                row,
+                resolutionsByMetadataRowId,
+                disabledRowIds,
+            );
+            if (effectiveValue === null) {
+                unmetRequiredRowIds.add(row.id);
+            }
+        }
+    }
+
+    return unmetRequiredRowIds;
 }

--- a/src/features/review/workspace/metadata/utils/group-session-units-by-identity.ts
+++ b/src/features/review/workspace/metadata/utils/group-session-units-by-identity.ts
@@ -5,6 +5,7 @@ import {
     buildMetadataRow,
     flattenQuestions,
     formatDisplayValue,
+    questionToMetadataField,
     type MetadataSection,
 } from './metadata-section';
 
@@ -83,10 +84,7 @@ export function buildUnitIdentitySections(
         ),
         rows: nonIdentityQuestions.map(question =>
             buildMetadataRow(
-                'formAnswer',
-                String(question.id),
-                question.label,
-                question.type,
+                questionToMetadataField(question),
                 new Map(
                     group.units.map(unit => [
                         unit.sessionId,

--- a/src/features/review/workspace/metadata/utils/group-session-units-by-identity.ts
+++ b/src/features/review/workspace/metadata/utils/group-session-units-by-identity.ts
@@ -47,7 +47,10 @@ export function buildUnitIdentitySections(
                 unitAnswers.map(answer => [answer.questionId, answer.value]),
             );
             const identityValues = identityQuestions.map(question =>
-                formatDisplayValue(valueByQuestionId.get(question.id) ?? null),
+                formatDisplayValue(
+                    valueByQuestionId.get(question.id) ?? null,
+                    question.type,
+                ),
             );
             const key =
                 identityQuestions.length > 0

--- a/src/features/review/workspace/metadata/utils/metadata-section.ts
+++ b/src/features/review/workspace/metadata/utils/metadata-section.ts
@@ -62,6 +62,30 @@ const SURVEILLANCE_FORM_FIELDS = [
     fieldType: FormQuestionType;
 }[];
 
+export const SURVEILLANCE_FIELD_DEPENDENCIES: Record<
+    string,
+    { dependentRowIds: string[]; disablingDisplayValues: string[] }
+> = {
+    'surveillanceForm.wasIrsConducted': {
+        dependentRowIds: ['surveillanceForm.monthsSinceIrs'],
+        disablingDisplayValues: ['No', NOT_APPLICABLE],
+    },
+    'surveillanceForm.numLlinsAvailable': {
+        dependentRowIds: [
+            'surveillanceForm.llinType',
+            'surveillanceForm.llinBrand',
+            'surveillanceForm.numPeopleSleptUnderLlin',
+        ],
+        disablingDisplayValues: ['0', NOT_APPLICABLE],
+    },
+};
+
+const SURVEILLANCE_REQUIRED_ROW_IDS = new Set(
+    Object.values(SURVEILLANCE_FIELD_DEPENDENCIES).flatMap(
+        dependency => dependency.dependentRowIds,
+    ),
+);
+
 export interface MetadataRow {
     id: string;
     label: string;
@@ -70,6 +94,8 @@ export interface MetadataRow {
     fieldType: FormQuestionType;
     fieldValueBySessionId: Map<number, unknown>;
     hasConflict: boolean;
+    required: boolean;
+    options: string[] | null;
 }
 
 export interface MetadataSection {
@@ -114,10 +140,15 @@ export function buildSurveillanceSection(
         } of SURVEILLANCE_FORM_FIELDS) {
             rows.push(
                 buildMetadataRow(
-                    'surveillanceForm',
-                    fieldName,
-                    label,
-                    fieldType,
+                    {
+                        entity: 'surveillanceForm',
+                        fieldName,
+                        label,
+                        fieldType,
+                        required: SURVEILLANCE_REQUIRED_ROW_IDS.has(
+                            `surveillanceForm.${fieldName}`,
+                        ),
+                    },
                     new Map(
                         sessions.map(session => [
                             session.sessionId,
@@ -146,10 +177,7 @@ export function buildDynamicSessionSection(
     )) {
         rows.push(
             buildMetadataRow(
-                'formAnswer',
-                String(question.id),
-                question.label,
-                question.type,
+                questionToMetadataField(question),
                 new Map(
                     sessions.map(session => [
                         session.sessionId,
@@ -169,10 +197,7 @@ export function buildDynamicSessionSection(
 function buildSessionCoreRows(sessions: Session[]): MetadataRow[] {
     return SESSION_FIELDS.map(({ fieldName, label, fieldType }) =>
         buildMetadataRow(
-            'session',
-            fieldName,
-            label,
-            fieldType,
+            { entity: 'session', fieldName, label, fieldType },
             new Map(
                 sessions.map(session => [
                     session.sessionId,
@@ -184,13 +209,18 @@ function buildSessionCoreRows(sessions: Session[]): MetadataRow[] {
 }
 
 export function buildMetadataRow(
-    entity: MetadataRow['entity'],
-    fieldName: string,
-    label: string,
-    fieldType: FormQuestionType,
+    field: {
+        entity: MetadataRow['entity'];
+        fieldName: string;
+        label: string;
+        fieldType: FormQuestionType;
+        required?: boolean;
+        options?: string[] | null;
+    },
     fieldValueBySessionId: Map<number, unknown>,
     groupKey?: string,
 ): MetadataRow {
+    const { entity, fieldName, label, fieldType, required, options } = field;
     const distinctDisplayValues = new Set(
         [...fieldValueBySessionId.values()].map(formatDisplayValue),
     );
@@ -204,5 +234,20 @@ export function buildMetadataRow(
         fieldType,
         fieldValueBySessionId,
         hasConflict: distinctDisplayValues.size > 1,
+        required: required ?? false,
+        options: options ?? null,
+    };
+}
+
+export function questionToMetadataField(
+    question: FormQuestion,
+): Parameters<typeof buildMetadataRow>[0] {
+    return {
+        entity: 'formAnswer',
+        fieldName: String(question.id),
+        label: question.label,
+        fieldType: question.type,
+        required: question.required,
+        options: question.options,
     };
 }

--- a/src/features/review/workspace/metadata/utils/metadata-section.ts
+++ b/src/features/review/workspace/metadata/utils/metadata-section.ts
@@ -105,10 +105,15 @@ export interface MetadataSection {
     sessionUnitIdBySessionId?: Map<number, number>;
 }
 
-export function formatDisplayValue(value: unknown): string {
+export function formatDisplayValue(
+    value: unknown,
+    fieldType?: FormQuestionType,
+): string {
     if (value == null) return NOT_APPLICABLE;
     if (typeof value === 'boolean')
         return value ? BOOLEAN_TRUE_DISPLAY : BOOLEAN_FALSE_DISPLAY;
+    if (fieldType === 'boolean' && (value === 'true' || value === 'false'))
+        return value === 'true' ? BOOLEAN_TRUE_DISPLAY : BOOLEAN_FALSE_DISPLAY;
     return String(value);
 }
 
@@ -222,7 +227,9 @@ export function buildMetadataRow(
 ): MetadataRow {
     const { entity, fieldName, label, fieldType, required, options } = field;
     const distinctDisplayValues = new Set(
-        [...fieldValueBySessionId.values()].map(formatDisplayValue),
+        [...fieldValueBySessionId.values()].map(value =>
+            formatDisplayValue(value, fieldType),
+        ),
     );
     return {
         id: groupKey


### PR DESCRIPTION


- Flag rows with a real `required` signal (FormQuestion.required or
  SURVEILLANCE_FIELD_DEPENDENCIES dependents) blocks Save & Continue
- Constrain `select`-type fields to their real defined options via a closed
  dropdown, matching the existing `boolean` pattern; boolean itself no longer
  leaks arbitrary recorded values into its own dropdown
- Fix `resolveRowEffectiveValue` using raw `String(value)` instead of
  `formatDisplayValue`, which silently broke the disable for
  boolean such as (`wasIrsConducted`/`monthsSinceIrs`)

- Make the metadata review table scroll within its own container with a
  sticky header